### PR TITLE
Fix issue with single byte manipulations

### DIFF
--- a/impl/src/bitfield.rs
+++ b/impl/src/bitfield.rs
@@ -167,7 +167,7 @@ impl BitfieldStruct {
 
                 let mut buffer = <T as modular_bitfield::Specifier>::Base::default();
 
-                if lsb_offset == 0 && msb_offset == 0 {
+                if lsb_offset == 0 && msb_offset == 8 {
                     // Edge-case for whole bytes manipulation.
                     for byte in self.data[ls_byte..(ms_byte + 1)].iter().rev() {
                         buffer.push_bits(8, *byte)

--- a/impl/src/bitfield.rs
+++ b/impl/src/bitfield.rs
@@ -209,14 +209,21 @@ impl BitfieldStruct {
 
                 let mut input = new_val;
 
-                if lsb_offset == 0 && msb_offset == 0 {
+                if lsb_offset == 0 && msb_offset == 8 {
                     // Edge-case for whole bytes manipulation.
                     for byte in self.data[ls_byte..(ms_byte + 1)].iter_mut() {
                         *byte = input.pop_bits(8);
                     }
                 } else {
                     // Least-significant byte
-                    let stays_same = self.data[ls_byte] & ((0x1 << lsb_offset as u32) - 1);
+                    let stays_same = self.data[ls_byte] &
+                        (
+                            if ls_byte == ms_byte && msb_offset != 8 {
+                                !((0x1 << msb_offset) - 1)
+                            } else {
+                                0
+                            } | ((0x1 << lsb_offset as u32) - 1)
+                        );
                     let overwrite = input.pop_bits(8 - lsb_offset as u32);
                     self.data[ls_byte] = stays_same | (overwrite << lsb_offset as u32);
 

--- a/tests/18-within-single-byte.rs
+++ b/tests/18-within-single-byte.rs
@@ -13,9 +13,10 @@ pub enum Mode {
 pub struct StatFlag {
     x: bool,
     y: bool,
-    z: B4,
+    z: B2,
     #[bits = 2]
     mode: Mode,
+    w: B2,
 }
 
 fn main() {
@@ -24,22 +25,43 @@ fn main() {
     assert_eq!(flag.get_x(), false);
     assert_eq!(flag.get_y(), false);
     assert_eq!(flag.get_z(), 0);
+    assert_eq!(flag.get_w(), 0);
     assert_eq!(flag.get_mode(), Mode::A);
 
     let new_mode = Mode::B;
 
     flag.set_mode(new_mode);
+    assert_eq!(flag.get_x(), false);
+    assert_eq!(flag.get_y(), false);
+    assert_eq!(flag.get_z(), 0);
+    assert_eq!(flag.get_w(), 0);
     assert_eq!(flag.get_mode(), new_mode);
-
+    
     flag.set_x(true);
     assert_eq!(flag.get_x(), true);
+    assert_eq!(flag.get_y(), false);
+    assert_eq!(flag.get_z(), 0);
+    assert_eq!(flag.get_w(), 0);
     assert_eq!(flag.get_mode(), new_mode);
 
     flag.set_y(true);
+    assert_eq!(flag.get_x(), true);
     assert_eq!(flag.get_y(), true);
+    assert_eq!(flag.get_z(), 0);
+    assert_eq!(flag.get_w(), 0);
     assert_eq!(flag.get_mode(), new_mode);
 
     flag.set_z(0b11);
+    assert_eq!(flag.get_x(), true);
+    assert_eq!(flag.get_y(), true);
     assert_eq!(flag.get_z(), 0b11);
+    assert_eq!(flag.get_w(), 0);
+    assert_eq!(flag.get_mode(), new_mode);
+
+    flag.set_w(0b01);
+    assert_eq!(flag.get_x(), true);
+    assert_eq!(flag.get_y(), true);
+    assert_eq!(flag.get_z(), 0b11);
+    assert_eq!(flag.get_w(), 0b01);
     assert_eq!(flag.get_mode(), new_mode);
 }

--- a/tests/18-within-single-byte.rs
+++ b/tests/18-within-single-byte.rs
@@ -1,0 +1,45 @@
+use modular_bitfield::prelude::*;
+
+#[derive(BitfieldSpecifier, Debug, PartialEq, Copy, Clone)]
+pub enum Mode {
+    A = 0b00,
+    B = 0b01,
+    C = 0b10,
+    D = 0b11,
+}
+
+#[bitfield]
+#[derive(Debug)]
+pub struct StatFlag {
+    x: bool,
+    y: bool,
+    z: B4,
+    #[bits = 2]
+    mode: Mode,
+}
+
+fn main() {
+    let mut flag = StatFlag::new();
+
+    assert_eq!(flag.get_x(), false);
+    assert_eq!(flag.get_y(), false);
+    assert_eq!(flag.get_z(), 0);
+    assert_eq!(flag.get_mode(), Mode::A);
+
+    let new_mode = Mode::B;
+
+    flag.set_mode(new_mode);
+    assert_eq!(flag.get_mode(), new_mode);
+
+    flag.set_x(true);
+    assert_eq!(flag.get_x(), true);
+    assert_eq!(flag.get_mode(), new_mode);
+
+    flag.set_y(true);
+    assert_eq!(flag.get_y(), true);
+    assert_eq!(flag.get_mode(), new_mode);
+
+    flag.set_z(0b11);
+    assert_eq!(flag.get_z(), 0b11);
+    assert_eq!(flag.get_mode(), new_mode);
+}

--- a/tests/progress.rs
+++ b/tests/progress.rs
@@ -20,4 +20,5 @@ fn tests() {
     t.pass("tests/15-manual-reset.rs");
     t.pass("tests/16-u128-specifier.rs");
     t.pass("tests/17-byte-conversions.rs");
+    t.pass("tests/18-within-single-byte.rs");
 }


### PR DESCRIPTION
Manipulations that targeted a single byte for both the MSB and LSB would not properly preserve any bits above the MSB.