### PR TITLE
Fix incorrect popping which introduced extra bits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,11 +51,11 @@
 //!     let mut example = Example::new();
 //!
 //!     // Assert that everything is inizialized to 0.
-//!     debug_assert_eq!(example.get_a(), false);
-//!     debug_assert_eq!(example.get_b(), 0);
-//!     debug_assert_eq!(example.get_c(), 0);
-//!     debug_assert_eq!(example.get_d(), DeliveryMode::Init);
-//!     debug_assert_eq!(example.get_e(), 0);
+//!     assert_eq!(example.get_a(), false);
+//!     assert_eq!(example.get_b(), 0);
+//!     assert_eq!(example.get_c(), 0);
+//!     assert_eq!(example.get_d(), DeliveryMode::Init);
+//!     assert_eq!(example.get_e(), 0);
 //!
 //!     // Modify the bitfields.
 //!     example.set_a(true);
@@ -65,20 +65,20 @@
 //!     example.set_e(1);                // Uses `u8`
 //!
 //!     // Assert the previous modifications.
-//!     debug_assert_eq!(example.get_a(), true);
-//!     debug_assert_eq!(example.get_b(), 0b0001_1111_1111_u16);
-//!     debug_assert_eq!(example.get_c(), 42);
-//!     debug_assert_eq!(example.get_d(), DeliveryMode::Startup);
-//!     debug_assert_eq!(example.get_e(), 1_u8);
+//!     assert_eq!(example.get_a(), true);
+//!     assert_eq!(example.get_b(), 0b0001_1111_1111_u16);
+//!     assert_eq!(example.get_c(), 42);
+//!     assert_eq!(example.get_d(), DeliveryMode::Startup);
+//!     assert_eq!(example.get_e(), 1_u8);
 //!
 //!     // Safe API allows for better testing
-//!     debug_assert_eq!(example.set_e_checked(200), Err(Error::OutOfBounds));
+//!     assert_eq!(example.set_e_checked(200), Err(Error::OutOfBounds));
 //!
 //!     // Can convert from and to bytes.
-//!     debug_assert_eq!(example.to_bytes(), &[255, 171, 128, 3]);
+//!     assert_eq!(example.to_bytes(), &[255, 171, 128, 3]);
 //!     use std::convert::TryFrom as _;
 //!     let copy = Example::try_from(example.to_bytes()).unwrap();
-//!     debug_assert_eq!(example, copy);
+//!     assert_eq!(example, copy);
 //! }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,11 +51,11 @@
 //!     let mut example = Example::new();
 //!
 //!     // Assert that everything is inizialized to 0.
-//!     assert_eq!(example.get_a(), false);
-//!     assert_eq!(example.get_b(), 0);
-//!     assert_eq!(example.get_c(), 0);
-//!     assert_eq!(example.get_d(), DeliveryMode::Init);
-//!     assert_eq!(example.get_e(), 0);
+//!     debug_assert_eq!(example.get_a(), false);
+//!     debug_assert_eq!(example.get_b(), 0);
+//!     debug_assert_eq!(example.get_c(), 0);
+//!     debug_assert_eq!(example.get_d(), DeliveryMode::Init);
+//!     debug_assert_eq!(example.get_e(), 0);
 //!
 //!     // Modify the bitfields.
 //!     example.set_a(true);
@@ -65,20 +65,20 @@
 //!     example.set_e(1);                // Uses `u8`
 //!
 //!     // Assert the previous modifications.
-//!     assert_eq!(example.get_a(), true);
-//!     assert_eq!(example.get_b(), 0b0001_1111_1111_u16);
-//!     assert_eq!(example.get_c(), 42);
-//!     assert_eq!(example.get_d(), DeliveryMode::Startup);
-//!     assert_eq!(example.get_e(), 1_u8);
+//!     debug_assert_eq!(example.get_a(), true);
+//!     debug_assert_eq!(example.get_b(), 0b0001_1111_1111_u16);
+//!     debug_assert_eq!(example.get_c(), 42);
+//!     debug_assert_eq!(example.get_d(), DeliveryMode::Startup);
+//!     debug_assert_eq!(example.get_e(), 1_u8);
 //!
 //!     // Safe API allows for better testing
-//!     assert_eq!(example.set_e_checked(200), Err(Error::OutOfBounds));
+//!     debug_assert_eq!(example.set_e_checked(200), Err(Error::OutOfBounds));
 //!
 //!     // Can convert from and to bytes.
-//!     assert_eq!(example.to_bytes(), &[255, 171, 128, 3]);
+//!     debug_assert_eq!(example.to_bytes(), &[255, 171, 128, 3]);
 //!     use std::convert::TryFrom as _;
 //!     let copy = Example::try_from(example.to_bytes()).unwrap();
-//!     assert_eq!(example, copy);
+//!     debug_assert_eq!(example, copy);
 //! }
 //! ```
 //!
@@ -232,7 +232,7 @@ impl PopBits for u8 {
             (v, false) => v,
             _ => 0,
         };
-        assert_eq!(res.count_ones() + self.count_ones(), orig_bits);
+        debug_assert_eq!(res.count_ones() + self.count_ones(), orig_bits);
         res
     }
 }
@@ -247,7 +247,7 @@ macro_rules! impl_push_bits {
                     debug_assert!(0 < amount && amount <= 8);
                     *self = self.wrapping_shl(amount);
                     *self |= (bits & (0xFF >> (8 - amount))) as $type;
-                    assert_eq!((bits & (0xFF >> (8 - amount))).count_ones() + orig_bits, self.count_ones());
+                    debug_assert_eq!((bits & (0xFF >> (8 - amount))).count_ones() + orig_bits, self.count_ones());
                 }
             }
         )+
@@ -269,7 +269,7 @@ macro_rules! impl_pop_bits {
                         (v, false) => v,
                         _ => 0,
                     };
-                    assert_eq!(res.count_ones() + self.count_ones(), orig_bits);
+                    debug_assert_eq!(res.count_ones() + self.count_ones(), orig_bits);
                     res
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,9 +225,14 @@ impl_sealed_for!(bool, u8, u16, u32, u64, u128);
 impl PopBits for u8 {
     #[inline(always)]
     fn pop_bits(&mut self, amount: u32) -> u8 {
+        let orig_bits = self.count_ones();
         debug_assert!(0 < amount && amount <= 8);
-        let res = *self & ((0x1_u16.wrapping_shl(amount) as u8).wrapping_sub(1));
-        *self /= 0x80 >> (8 - amount);
+        let res = *self & ((0x1_u16.wrapping_shl(amount)).wrapping_sub(1) as u8);
+        *self = match self.overflowing_shr(amount) {
+            (v, false) => v,
+            _ => 0,
+        };
+        assert_eq!(res.count_ones() + self.count_ones(), orig_bits);
         res
     }
 }
@@ -238,9 +243,11 @@ macro_rules! impl_push_bits {
             impl PushBits for $type {
                 #[inline(always)]
                 fn push_bits(&mut self, amount: u32, bits: u8) {
+                    let orig_bits = self.count_ones();
                     debug_assert!(0 < amount && amount <= 8);
                     *self = self.wrapping_shl(amount);
                     *self |= (bits & (0xFF >> (8 - amount))) as $type;
+                    assert_eq!((bits & (0xFF >> (8 - amount))).count_ones() + orig_bits, self.count_ones());
                 }
             }
         )+
@@ -255,9 +262,14 @@ macro_rules! impl_pop_bits {
             impl PopBits for $type {
                 #[inline(always)]
                 fn pop_bits(&mut self, amount: u32) -> u8 {
+                    let orig_bits = self.count_ones();
                     debug_assert!(0 < amount && amount <= 8);
                     let res = (*self & (0xFF >> (8 - amount))) as u8;
-                    *self /= 0x1 << amount;
+                    *self = match self.overflowing_shr(amount) {
+                        (v, false) => v,
+                        _ => 0,
+                    };
+                    assert_eq!(res.count_ones() + self.count_ones(), orig_bits);
                     res
                 }
             }

--- a/tests/19-get-spanning-data.rs
+++ b/tests/19-get-spanning-data.rs
@@ -1,0 +1,30 @@
+use modular_bitfield::prelude::*;
+use std::convert::TryFrom;
+
+#[bitfield]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ColorEntry {    
+    r : B5,    
+    g : B5,
+    b : B5,
+    unused: B1,
+}
+
+fn main() {
+    for i in 0..=std::u16::MAX {
+        let entry = ColorEntry::try_from(&i.to_le_bytes()[..]).unwrap();
+        let mut new = ColorEntry::new();
+        new.set_r(entry.get_r());
+        assert_eq!(new.get_r(), entry.get_r());
+        new.set_g(entry.get_g());    
+        assert_eq!(new.get_g(), entry.get_g());
+        new.set_b(entry.get_b());
+        assert_eq!(new.get_b(), entry.get_b());
+        new.set_unused(entry.get_unused());
+        
+        assert_eq!(new.get_r(), entry.get_r());
+        assert_eq!(new.get_g(), entry.get_g());
+        assert_eq!(new.get_b(), entry.get_b());
+        assert_eq!(new.get_unused(), entry.get_unused());
+    }
+}

--- a/tests/progress.rs
+++ b/tests/progress.rs
@@ -21,4 +21,5 @@ fn tests() {
     t.pass("tests/16-u128-specifier.rs");
     t.pass("tests/17-byte-conversions.rs");
     t.pass("tests/18-within-single-byte.rs");
+    t.pass("tests/19-get-spanning-data.rs");
 }


### PR DESCRIPTION
There was another issue due to some incorrect shifting which introduced extra bits during the `pop_bits` routine.