### PR TITLE
Change the getter names to be the field name

### DIFF
--- a/impl/src/bitfield.rs
+++ b/impl/src/bitfield.rs
@@ -261,7 +261,7 @@ impl BitfieldStruct {
                 .as_ref()
                 .map(ToString::to_string)
                 .unwrap_or(format!("{}", n));
-            let getter_name = syn::Ident::from_str(format!("get_{}", field_name));
+            let getter_name = syn::Ident::from_str(field_name.clone());
             let setter_name = syn::Ident::from_str(format!("set_{}", field_name));
             let checked_setter_name = syn::Ident::from_str(format!("set_{}_checked", field_name));
             let field_type = &field.ty;

--- a/impl/src/bitfield.rs
+++ b/impl/src/bitfield.rs
@@ -261,7 +261,13 @@ impl BitfieldStruct {
                 .as_ref()
                 .map(ToString::to_string)
                 .unwrap_or(format!("{}", n));
-            let getter_name = syn::Ident::from_str(field_name.clone());
+            let getter_name = syn::Ident::from_str(
+                if field.ident.is_some() {
+                    field_name.clone()
+                } else {
+                    format!("get_{}", field_name)
+                }
+            );
             let setter_name = syn::Ident::from_str(format!("set_{}", field_name));
             let checked_setter_name = syn::Ident::from_str(format!("set_{}_checked", field_name));
             let field_type = &field.ty;

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -42,15 +42,15 @@ pub fn define_specifiers(input: TokenStream) -> TokenStream {
 ///
 /// fn main() {
 ///     let mut example = Example::new();
-///     assert_eq!(example.get_a(), 0);
-///     assert_eq!(example.get_b(), 0);
-///     assert_eq!(example.get_c(), 0);
+///     assert_eq!(example.a(), 0);
+///     assert_eq!(example.b(), 0);
+///     assert_eq!(example.c(), 0);
 ///     example.set_a(1);
 ///     example.set_b(0b0100_0000);
 ///     example.set_c(1337);
-///     assert_eq!(example.get_a(), 1);
-///     assert_eq!(example.get_b(), 0b0100_0000);
-///     assert_eq!(example.get_c(), 1337);
+///     assert_eq!(example.a(), 1);
+///     assert_eq!(example.b(), 0b0100_0000);
+///     assert_eq!(example.c(), 1337);
 /// }
 /// ```
 #[proc_macro_attribute]
@@ -86,12 +86,12 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// fn main() {
 ///     let mut example = Example::new();
-///     assert_eq!(example.get_a(), false); // `false as u8` is 0
-///     assert_eq!(example.get_b(), Mode::Sleep);
+///     assert_eq!(example.a(), false); // `false as u8` is 0
+///     assert_eq!(example.b(), Mode::Sleep);
 ///     example.set_a(true);
 ///     example.set_b(Mode::Awake);
-///     assert_eq!(example.get_a(), true); // `true as u8` is 1
-///     assert_eq!(example.get_b(), Mode::Awake);
+///     assert_eq!(example.a(), true); // `true as u8` is 1
+///     assert_eq!(example.b(), Mode::Awake);
 /// }
 /// ```
 #[proc_macro_derive(BitfieldSpecifier)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,11 +51,11 @@
 //!     let mut example = Example::new();
 //!
 //!     // Assert that everything is inizialized to 0.
-//!     assert_eq!(example.get_a(), false);
-//!     assert_eq!(example.get_b(), 0);
-//!     assert_eq!(example.get_c(), 0);
-//!     assert_eq!(example.get_d(), DeliveryMode::Init);
-//!     assert_eq!(example.get_e(), 0);
+//!     assert_eq!(example.a(), false);
+//!     assert_eq!(example.b(), 0);
+//!     assert_eq!(example.c(), 0);
+//!     assert_eq!(example.d(), DeliveryMode::Init);
+//!     assert_eq!(example.e(), 0);
 //!
 //!     // Modify the bitfields.
 //!     example.set_a(true);
@@ -65,11 +65,11 @@
 //!     example.set_e(1);                // Uses `u8`
 //!
 //!     // Assert the previous modifications.
-//!     assert_eq!(example.get_a(), true);
-//!     assert_eq!(example.get_b(), 0b0001_1111_1111_u16);
-//!     assert_eq!(example.get_c(), 42);
-//!     assert_eq!(example.get_d(), DeliveryMode::Startup);
-//!     assert_eq!(example.get_e(), 1_u8);
+//!     assert_eq!(example.a(), true);
+//!     assert_eq!(example.b(), 0b0001_1111_1111_u16);
+//!     assert_eq!(example.c(), 42);
+//!     assert_eq!(example.d(), DeliveryMode::Startup);
+//!     assert_eq!(example.e(), 1_u8);
 //!
 //!     // Safe API allows for better testing
 //!     assert_eq!(example.set_e_checked(200), Err(Error::OutOfBounds));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,10 @@
 //!     External,
 //! }
 //!
+//! /// Tuple structs can also be used as bitfields.
+//! #[bitfield]
+//! pub struct TupleStruct(bool, B4, DeliveryMode);
+//!
 //! fn main() {
 //!     let mut example = Example::new();
 //!
@@ -79,6 +83,15 @@
 //!     use std::convert::TryFrom as _;
 //!     let copy = Example::try_from(example.to_bytes()).unwrap();
 //!     assert_eq!(example, copy);
+//!
+//!     // Accessing fields of a tuple struct bitfield
+//!     // uses the `get_n()` and `set_n()` functions.
+//!     let mut tuple_example = TupleStruct::new();
+//!     assert_eq!(tuple_example.get_0(), false);
+//!     assert_eq!(tuple_example.get_1(), 0);
+//!     assert_eq!(tuple_example.get_2(), DeliveryMode::Init);
+//!     tuple_example.set_2(DeliveryMode::Fixed);
+//!     assert_eq!(tuple_example.get_2(), DeliveryMode::Fixed);
 //! }
 //! ```
 //!

--- a/tests/03-accessors.rs
+++ b/tests/03-accessors.rs
@@ -30,14 +30,14 @@ pub struct MyFourBytes {
 
 fn main() {
     let mut bitfield = MyFourBytes::new();
-    assert_eq!(0, bitfield.get_a());
-    assert_eq!(0, bitfield.get_b());
-    assert_eq!(0, bitfield.get_c());
-    assert_eq!(0, bitfield.get_d());
+    assert_eq!(0, bitfield.a());
+    assert_eq!(0, bitfield.b());
+    assert_eq!(0, bitfield.c());
+    assert_eq!(0, bitfield.d());
 
     bitfield.set_c(14);
-    assert_eq!(0, bitfield.get_a());
-    assert_eq!(0, bitfield.get_b());
-    assert_eq!(14, bitfield.get_c());
-    assert_eq!(0, bitfield.get_d());
+    assert_eq!(0, bitfield.a());
+    assert_eq!(0, bitfield.b());
+    assert_eq!(14, bitfield.c());
+    assert_eq!(0, bitfield.d());
 }

--- a/tests/05-accessor-signatures.rs
+++ b/tests/05-accessor-signatures.rs
@@ -24,7 +24,7 @@ fn main() {
 
     // I am testing the signatures in this roundabout way to avoid making it
     // possible to pass this test with a generic signature that is inconvenient
-    // for callers, such as `fn get_a<T: From<u64>>(&self) -> T`.
+    // for callers, such as `fn a<T: From<u64>>(&self) -> T`.
 
     let a = 1;
     x.set_a(a); // expect fn(&mut MyFourBytes, u8)
@@ -40,8 +40,8 @@ fn main() {
     assert_eq!(size_of_val(&c), 1);
     assert_eq!(size_of_val(&d), 4);
 
-    assert_eq!(size_of_val(&x.get_a()), 1); // expect fn(&MyFourBytes) -> u8
-    assert_eq!(size_of_val(&x.get_b()), 1);
-    assert_eq!(size_of_val(&x.get_c()), 1);
-    assert_eq!(size_of_val(&x.get_d()), 4); // expect fn(&MyFourBytes) -> u32
+    assert_eq!(size_of_val(&x.a()), 1); // expect fn(&MyFourBytes) -> u8
+    assert_eq!(size_of_val(&x.b()), 1);
+    assert_eq!(size_of_val(&x.c()), 1);
+    assert_eq!(size_of_val(&x.d()), 4); // expect fn(&MyFourBytes) -> u32
 }

--- a/tests/06-enums.rs
+++ b/tests/06-enums.rs
@@ -79,13 +79,13 @@ fn main() {
 
     // Initialized to all 0 bits.
     let mut entry = RedirectionTableEntry::new();
-    assert_eq!(entry.get_acknowledged(), false);
-    assert_eq!(entry.get_trigger_mode(), TriggerMode::Edge);
-    assert_eq!(entry.get_delivery_mode(), DeliveryMode::Fixed);
+    assert_eq!(entry.acknowledged(), false);
+    assert_eq!(entry.trigger_mode(), TriggerMode::Edge);
+    assert_eq!(entry.delivery_mode(), DeliveryMode::Fixed);
 
     entry.set_acknowledged(true);
     entry.set_delivery_mode(DeliveryMode::SMI);
-    assert_eq!(entry.get_acknowledged(), true);
-    assert_eq!(entry.get_trigger_mode(), TriggerMode::Edge);
-    assert_eq!(entry.get_delivery_mode(), DeliveryMode::SMI);
+    assert_eq!(entry.acknowledged(), true);
+    assert_eq!(entry.trigger_mode(), TriggerMode::Edge);
+    assert_eq!(entry.delivery_mode(), DeliveryMode::SMI);
 }

--- a/tests/07-optional-discriminant.rs
+++ b/tests/07-optional-discriminant.rs
@@ -42,8 +42,8 @@ fn main() {
 
     // Initialized to all 0 bits.
     let mut entry = RedirectionTableEntry::new();
-    assert_eq!(entry.get_delivery_mode(), DeliveryMode::Init);
+    assert_eq!(entry.delivery_mode(), DeliveryMode::Init);
 
     entry.set_delivery_mode(DeliveryMode::Lowest);
-    assert_eq!(entry.get_delivery_mode(), DeliveryMode::Lowest);
+    assert_eq!(entry.delivery_mode(), DeliveryMode::Lowest);
 }

--- a/tests/12-accessors-edge.rs
+++ b/tests/12-accessors-edge.rs
@@ -21,10 +21,10 @@ pub struct EdgeCaseBytes {
 
 fn main() {
     let mut bitfield = EdgeCaseBytes::new();
-    assert_eq!(0, bitfield.get_a());
-    assert_eq!(0, bitfield.get_b());
-    assert_eq!(0, bitfield.get_c());
-    assert_eq!(0, bitfield.get_d());
+    assert_eq!(0, bitfield.a());
+    assert_eq!(0, bitfield.b());
+    assert_eq!(0, bitfield.c());
+    assert_eq!(0, bitfield.d());
 
     let a = 0b1100_0011_1;
     let b = 0b101_010;
@@ -36,8 +36,8 @@ fn main() {
     bitfield.set_c(c);
     bitfield.set_d(d);
 
-    assert_eq!(a, bitfield.get_a());
-    assert_eq!(b, bitfield.get_b());
-    assert_eq!(c, bitfield.get_c());
-    assert_eq!(d, bitfield.get_d());
+    assert_eq!(a, bitfield.a());
+    assert_eq!(b, bitfield.b());
+    assert_eq!(c, bitfield.c());
+    assert_eq!(d, bitfield.d());
 }

--- a/tests/14-checked-setters.rs
+++ b/tests/14-checked-setters.rs
@@ -13,9 +13,9 @@ fn main() {
     let mut bitfield = MyTwoBytes::new();
 
     // Everything is initialized to zero.
-    assert_eq!(bitfield.get_a(), 0);
-    assert_eq!(bitfield.get_b(), 0);
-    assert_eq!(bitfield.get_c(), 0);
+    assert_eq!(bitfield.a(), 0);
+    assert_eq!(bitfield.b(), 0);
+    assert_eq!(bitfield.c(), 0);
 
     // Do some invalid manipulations.
     assert_eq!(bitfield.set_a_checked(2), Err(Error::OutOfBounds));
@@ -23,9 +23,9 @@ fn main() {
     assert_eq!(bitfield.set_c_checked(12345), Err(Error::OutOfBounds));
 
     // Asserts that nothing has changed.
-    assert_eq!(bitfield.get_a(), 0);
-    assert_eq!(bitfield.get_b(), 0);
-    assert_eq!(bitfield.get_c(), 0);
+    assert_eq!(bitfield.a(), 0);
+    assert_eq!(bitfield.b(), 0);
+    assert_eq!(bitfield.c(), 0);
 
     // Do some valid manipulations.
     assert_eq!(bitfield.set_a_checked(1), Ok(()));
@@ -33,7 +33,7 @@ fn main() {
     assert_eq!(bitfield.set_c_checked(42), Ok(()));
 
     // Asserts that the valid manipulation has had effect.
-    assert_eq!(bitfield.get_a(), 1);
-    assert_eq!(bitfield.get_b(), 3);
-    assert_eq!(bitfield.get_c(), 42);
+    assert_eq!(bitfield.a(), 1);
+    assert_eq!(bitfield.b(), 3);
+    assert_eq!(bitfield.c(), 42);
 }

--- a/tests/15-manual-reset.rs
+++ b/tests/15-manual-reset.rs
@@ -13,9 +13,9 @@ fn main() {
     let mut bitfield = MyTwoBytes::new();
 
     // Everything is initialized to zero.
-    assert_eq!(bitfield.get_a(), 0);
-    assert_eq!(bitfield.get_b(), 0);
-    assert_eq!(bitfield.get_c(), 0);
+    assert_eq!(bitfield.a(), 0);
+    assert_eq!(bitfield.b(), 0);
+    assert_eq!(bitfield.c(), 0);
 
     // Manipulate bitfield.
     bitfield.set_a(1);
@@ -23,9 +23,9 @@ fn main() {
     bitfield.set_c(42);
 
     // Check that manipulation was successful.
-    assert_eq!(bitfield.get_a(), 1);
-    assert_eq!(bitfield.get_b(), 3);
-    assert_eq!(bitfield.get_c(), 42);
+    assert_eq!(bitfield.a(), 1);
+    assert_eq!(bitfield.b(), 3);
+    assert_eq!(bitfield.c(), 42);
 
     // Manually reset the bitfield.
     bitfield.set_a(0);
@@ -33,7 +33,7 @@ fn main() {
     bitfield.set_c(0);
 
     // Check if reset was successful.
-    assert_eq!(bitfield.get_a(), 0);
-    assert_eq!(bitfield.get_b(), 0);
-    assert_eq!(bitfield.get_c(), 0);
+    assert_eq!(bitfield.a(), 0);
+    assert_eq!(bitfield.b(), 0);
+    assert_eq!(bitfield.c(), 0);
 }

--- a/tests/16-u128-specifier.rs
+++ b/tests/16-u128-specifier.rs
@@ -13,9 +13,9 @@ fn main() {
     let mut bitfield = SomeMoreBytes::new();
 
     // Everything is initialized to zero.
-    assert_eq!(bitfield.get_a(), 0);
-    assert_eq!(bitfield.get_b(), 0);
-    assert_eq!(bitfield.get_c(), 0);
+    assert_eq!(bitfield.a(), 0);
+    assert_eq!(bitfield.b(), 0);
+    assert_eq!(bitfield.c(), 0);
 
     // Manipulate bitfield.
     assert_eq!(bitfield.set_a_checked(1), Ok(()));
@@ -23,9 +23,9 @@ fn main() {
     assert_eq!(bitfield.set_c_checked(42), Ok(()));
 
     // Check that manipulation was successful.
-    assert_eq!(bitfield.get_a(), 1);
-    assert_eq!(bitfield.get_b(), 3);
-    assert_eq!(bitfield.get_c(), 42);
+    assert_eq!(bitfield.a(), 1);
+    assert_eq!(bitfield.b(), 3);
+    assert_eq!(bitfield.c(), 42);
 
     // // Manually reset the bitfield.
     bitfield.set_a(0);
@@ -33,7 +33,7 @@ fn main() {
     bitfield.set_c(0);
 
     // // Check if reset was successful.
-    assert_eq!(bitfield.get_a(), 0);
-    assert_eq!(bitfield.get_b(), 0);
-    assert_eq!(bitfield.get_c(), 0);
+    assert_eq!(bitfield.a(), 0);
+    assert_eq!(bitfield.b(), 0);
+    assert_eq!(bitfield.c(), 0);
 }

--- a/tests/17-byte-conversions.rs
+++ b/tests/17-byte-conversions.rs
@@ -19,10 +19,10 @@ fn main() {
     bitfield_1.set_c(444);
     bitfield_1.set_d(1337);
 
-    assert_eq!(bitfield_1.get_a(), true);
-    assert_eq!(bitfield_1.get_b(), 3);
-    assert_eq!(bitfield_1.get_c(), 444);
-    assert_eq!(bitfield_1.get_d(), 1337);
+    assert_eq!(bitfield_1.a(), true);
+    assert_eq!(bitfield_1.b(), 3);
+    assert_eq!(bitfield_1.c(), 444);
+    assert_eq!(bitfield_1.d(), 1337);
 
     let bytes = bitfield_1.to_bytes();
     assert_eq!(bytes, &[231, 13, 57, 5]);
@@ -30,10 +30,10 @@ fn main() {
     use std::convert::TryFrom;
     let bitfield2 = MyFourBytes::try_from(bytes).unwrap();
 
-    assert_eq!(bitfield2.get_a(), true);
-    assert_eq!(bitfield2.get_b(), 3);
-    assert_eq!(bitfield2.get_c(), 444);
-    assert_eq!(bitfield2.get_d(), 1337);
+    assert_eq!(bitfield2.a(), true);
+    assert_eq!(bitfield2.b(), 3);
+    assert_eq!(bitfield2.c(), 444);
+    assert_eq!(bitfield2.d(), 1337);
 
     let too_few_bytes = &bytes[0..2];
     let too_many_bytes = {

--- a/tests/18-within-single-byte.rs
+++ b/tests/18-within-single-byte.rs
@@ -22,46 +22,46 @@ pub struct StatFlag {
 fn main() {
     let mut flag = StatFlag::new();
 
-    assert_eq!(flag.get_x(), false);
-    assert_eq!(flag.get_y(), false);
-    assert_eq!(flag.get_z(), 0);
-    assert_eq!(flag.get_w(), 0);
-    assert_eq!(flag.get_mode(), Mode::A);
+    assert_eq!(flag.x(), false);
+    assert_eq!(flag.y(), false);
+    assert_eq!(flag.z(), 0);
+    assert_eq!(flag.w(), 0);
+    assert_eq!(flag.mode(), Mode::A);
 
     let new_mode = Mode::B;
 
     flag.set_mode(new_mode);
-    assert_eq!(flag.get_x(), false);
-    assert_eq!(flag.get_y(), false);
-    assert_eq!(flag.get_z(), 0);
-    assert_eq!(flag.get_w(), 0);
-    assert_eq!(flag.get_mode(), new_mode);
+    assert_eq!(flag.x(), false);
+    assert_eq!(flag.y(), false);
+    assert_eq!(flag.z(), 0);
+    assert_eq!(flag.w(), 0);
+    assert_eq!(flag.mode(), new_mode);
     
     flag.set_x(true);
-    assert_eq!(flag.get_x(), true);
-    assert_eq!(flag.get_y(), false);
-    assert_eq!(flag.get_z(), 0);
-    assert_eq!(flag.get_w(), 0);
-    assert_eq!(flag.get_mode(), new_mode);
+    assert_eq!(flag.x(), true);
+    assert_eq!(flag.y(), false);
+    assert_eq!(flag.z(), 0);
+    assert_eq!(flag.w(), 0);
+    assert_eq!(flag.mode(), new_mode);
 
     flag.set_y(true);
-    assert_eq!(flag.get_x(), true);
-    assert_eq!(flag.get_y(), true);
-    assert_eq!(flag.get_z(), 0);
-    assert_eq!(flag.get_w(), 0);
-    assert_eq!(flag.get_mode(), new_mode);
+    assert_eq!(flag.x(), true);
+    assert_eq!(flag.y(), true);
+    assert_eq!(flag.z(), 0);
+    assert_eq!(flag.w(), 0);
+    assert_eq!(flag.mode(), new_mode);
 
     flag.set_z(0b11);
-    assert_eq!(flag.get_x(), true);
-    assert_eq!(flag.get_y(), true);
-    assert_eq!(flag.get_z(), 0b11);
-    assert_eq!(flag.get_w(), 0);
-    assert_eq!(flag.get_mode(), new_mode);
+    assert_eq!(flag.x(), true);
+    assert_eq!(flag.y(), true);
+    assert_eq!(flag.z(), 0b11);
+    assert_eq!(flag.w(), 0);
+    assert_eq!(flag.mode(), new_mode);
 
     flag.set_w(0b01);
-    assert_eq!(flag.get_x(), true);
-    assert_eq!(flag.get_y(), true);
-    assert_eq!(flag.get_z(), 0b11);
-    assert_eq!(flag.get_w(), 0b01);
-    assert_eq!(flag.get_mode(), new_mode);
+    assert_eq!(flag.x(), true);
+    assert_eq!(flag.y(), true);
+    assert_eq!(flag.z(), 0b11);
+    assert_eq!(flag.w(), 0b01);
+    assert_eq!(flag.mode(), new_mode);
 }

--- a/tests/19-get-spanning-data.rs
+++ b/tests/19-get-spanning-data.rs
@@ -14,17 +14,17 @@ fn main() {
     for i in 0..=std::u16::MAX {
         let entry = ColorEntry::try_from(&i.to_le_bytes()[..]).unwrap();
         let mut new = ColorEntry::new();
-        new.set_r(entry.get_r());
-        assert_eq!(new.get_r(), entry.get_r());
-        new.set_g(entry.get_g());    
-        assert_eq!(new.get_g(), entry.get_g());
-        new.set_b(entry.get_b());
-        assert_eq!(new.get_b(), entry.get_b());
-        new.set_unused(entry.get_unused());
+        new.set_r(entry.r());
+        assert_eq!(new.r(), entry.r());
+        new.set_g(entry.g());    
+        assert_eq!(new.g(), entry.g());
+        new.set_b(entry.b());
+        assert_eq!(new.b(), entry.b());
+        new.set_unused(entry.unused());
         
-        assert_eq!(new.get_r(), entry.get_r());
-        assert_eq!(new.get_g(), entry.get_g());
-        assert_eq!(new.get_b(), entry.get_b());
-        assert_eq!(new.get_unused(), entry.get_unused());
+        assert_eq!(new.r(), entry.r());
+        assert_eq!(new.g(), entry.g());
+        assert_eq!(new.b(), entry.b());
+        assert_eq!(new.unused(), entry.unused());
     }
 }


### PR DESCRIPTION
Closes #14. Tuple struct getters are left as-is, since their field names are invalid identifiers. This is now documented in the crate showcase.