### PR TITLE
Fix compile error

### DIFF
--- a/impl/src/bitfield_specifier.rs
+++ b/impl/src/bitfield_specifier.rs
@@ -84,7 +84,7 @@ pub fn generate3(input: syn::ItemEnum) -> syn::Result<TokenStream2> {
         from_bits_match_arms.extend(quote! {
             #snake_variant if #snake_variant == #enum_ident::#variant as <#enum_ident as modular_bitfield::Specifier>::Base => {
                 #enum_ident::#variant
-            }
+            },
         });
     }
 

--- a/tests/04-multiple-of-8bits.stderr
+++ b/tests/04-multiple-of-8bits.stderr
@@ -3,5 +3,10 @@ error[E0277]: the trait bound `modular_bitfield::checks::SevenMod8: modular_bitf
    |
 53 | #[bitfield]
    | ^^^^^^^^^^^ the trait `modular_bitfield::checks::TotalSizeIsMultipleOfEightBits` is not implemented for `modular_bitfield::checks::SevenMod8`
-
-For more information about this error, try `rustc --explain E0277`.
+   |
+  ::: $WORKSPACE/src/checks.rs
+   |
+   |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsMultipleOfEightBits,
+   |                                                ------------------------------ required by this bound in `modular_bitfield::checks::CheckTotalSizeMultipleOf8`
+   |
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/08-non-power-of-two.stderr
+++ b/tests/08-non-power-of-two.stderr
@@ -3,3 +3,5 @@ error: BitfieldSpecifier expected a number of variants which is a power of 2
    |
 10 | #[derive(BitfieldSpecifier)]
    |          ^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/09-variant-out-of-range.stderr
+++ b/tests/09-variant-out-of-range.stderr
@@ -1,7 +1,10 @@
 error[E0277]: the trait bound `modular_bitfield::checks::False: modular_bitfield::checks::DiscriminantInRange` is not satisfied
-  --> $DIR/09-variant-out-of-range.rs:17:5
-   |
-17 |     External,
-   |     ^^^^^^^^ the trait `modular_bitfield::checks::DiscriminantInRange` is not implemented for `modular_bitfield::checks::False`
-
-For more information about this error, try `rustc --explain E0277`.
+   --> $DIR/09-variant-out-of-range.rs:17:5
+    |
+17  |     External,
+    |     ^^^^^^^^ the trait `modular_bitfield::checks::DiscriminantInRange` is not implemented for `modular_bitfield::checks::False`
+    |
+   ::: $WORKSPACE/src/checks.rs
+    |
+    |     <Self::CheckType as DispatchTrueFalse>::Out: DiscriminantInRange
+    |                                                  ------------------- required by this bound in `modular_bitfield::checks::CheckDiscriminantInRange`

--- a/tests/11-bits-attribute-wrong.stderr
+++ b/tests/11-bits-attribute-wrong.stderr
@@ -3,8 +3,3 @@ error[E0308]: mismatched types
    |
 11 |     #[bits = 9]
    |              ^ expected an array with a fixed size of 9 elements, found one with 1 element
-   |
-   = note: expected type `[(); 9]`
-              found type `[(); 1]`
-
-For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
I have this code:
```Rust
#[bitfield]
#[derive(Debug, PartialEq, Eq)]
struct Instruction {
    #[bits = 4]
    opcode: OpCode,
    data: B12,
}

#[derive(BitfieldSpecifier, Debug, PartialEq)]
pub enum OpCode {
    BR,
    ADD,
    LD,
    ST,
    JSR,
    AND,
    LDR,
    STR,
    RTI,
    NOT,
    LDI,
    STI,
    JMP,
    RES,
    LEA,
    TRAP,
}
```
Compilation failed with error:
```
error: `and` is not a logical operator
  --> src/main.rs:11:10
   |
11 | #[derive(BitfieldSpecifier, Debug, PartialEq)]
   |          ^^^^^^^^^^^^^^^^^ help: use `&&` to perform logical conjunction
   |
   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: proc-macro derive produced unparseable tokens
  --> src/main.rs:11:10
   |
11 | #[derive(BitfieldSpecifier, Debug, PartialEq)]
   |          ^^^^^^^^^^^^^^^^^
```
Adding comma between branches of `match`, generated by `#[derive(BitfieldSpecifier)]` fixes it :)