### PR TITLE
Add .with() syntax

### DIFF
--- a/tests/14-checked-setters.rs
+++ b/tests/14-checked-setters.rs
@@ -3,6 +3,7 @@
 use modular_bitfield::prelude::*;
 
 #[bitfield]
+#[derive(Debug, PartialEq)]
 pub struct MyTwoBytes {
     a: B1,
     b: B2,
@@ -35,5 +36,18 @@ fn main() {
     // Asserts that the valid manipulation has had effect.
     assert_eq!(bitfield.a(), 1);
     assert_eq!(bitfield.b(), 3);
+    assert_eq!(bitfield.c(), 42);
+
+    // Check the checked with statement throws error
+    assert_eq!(MyTwoBytes::new().with_a_checked(2), Err(Error::OutOfBounds));
+    assert_eq!(MyTwoBytes::new().with_a_checked(1).unwrap().with_b_checked(4), Err(Error::OutOfBounds));
+
+    // Check that with_checked populates values without touching other fields
+    let bitfield = bitfield
+        .with_a_checked(0).unwrap()
+        .with_b_checked(2).unwrap();
+
+    assert_eq!(bitfield.a(), 0);
+    assert_eq!(bitfield.b(), 2);
     assert_eq!(bitfield.c(), 42);
 }

--- a/tests/22-with-setter.rs
+++ b/tests/22-with-setter.rs
@@ -1,0 +1,32 @@
+// Generate getters and.with() setters that manipulate the right range of bits
+// corresponding to each field.
+//
+//
+//     ║  first byte   ║  second byte  ║  third byte   ║  fourth byte  ║
+//     ╟───────────────╫───────────────╫───────────────╫───────────────╢
+//     ║▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒║
+//     ╟─╫─────╫───────╫───────────────────────────────────────────────╢
+//     ║a║  b  ║   c   ║                       d                       ║
+
+use modular_bitfield::prelude::*;
+
+#[bitfield]
+pub struct MyFourBytes {
+    a: bool,
+    b: B3,
+    c: B4,
+    d: B24,
+}
+
+fn main() {
+    let bitfield = MyFourBytes::new()
+        .with_a(true)
+        .with_b(2)
+        .with_c(14)
+        .with_d(1_000_000);
+
+    assert_eq!(bitfield.a(), true);
+    assert_eq!(bitfield.b(), 2);
+    assert_eq!(bitfield.c(), 14);
+    assert_eq!(bitfield.d(), 1_000_000);
+}

--- a/tests/progress.rs
+++ b/tests/progress.rs
@@ -24,4 +24,5 @@ fn tests() {
     t.pass("tests/19-get-spanning-data.rs");
     t.compile_fail("tests/20-access-test.rs");
     t.pass("tests/21-raw-identifiers.rs");
+    t.pass("tests/22-with-setter.rs");
 }


### PR DESCRIPTION
.with() and .with_checked() allow creating bitfields without using
mutable variable.

Fixes #17 