### PR TITLE
Implements visibility for struct and fields, closes #21

### DIFF
--- a/impl/src/bitfield.rs
+++ b/impl/src/bitfield.rs
@@ -83,7 +83,7 @@ impl BitfieldStruct {
             impl #ident
             {
                 /// Returns an instance with zero initialized data
-                fn new() -> Self {
+                pub fn new() -> Self {
                     Self {
                         data: [0; (#size) / 8],
                     }
@@ -110,7 +110,7 @@ impl BitfieldStruct {
                 /// The returned byte slice is layed out in the same way as described
                 /// [here](https://docs.rs/modular-bitfield/#generated-structure).
                 #[inline]
-                fn to_bytes(&self) -> &[u8] {
+                pub fn to_bytes(&self) -> &[u8] {
                     &self.data
                 }
             }

--- a/tests/08-non-power-of-two.stderr
+++ b/tests/08-non-power-of-two.stderr
@@ -5,5 +5,3 @@ error: BitfieldSpecifier expected a number of variants which is a power of 2
    |          ^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: could not compile `modular-bitfield-tests`.

--- a/tests/11-bits-attribute-wrong.stderr
+++ b/tests/11-bits-attribute-wrong.stderr
@@ -3,6 +3,3 @@ error[E0308]: mismatched types
    |
 11 |     #[bits = 9]
    |              ^ expected an array with a fixed size of 9 elements, found one with 1 element
-
-For more information about this error, try `rustc --explain E0308`.
-error: could not compile `modular-bitfield-tests`.

--- a/tests/19-get-spanning-data.rs
+++ b/tests/19-get-spanning-data.rs
@@ -3,10 +3,10 @@ use std::convert::TryFrom;
 
 #[bitfield]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct ColorEntry {    
-    r : B5,    
-    g : B5,
-    b : B5,
+pub struct ColorEntry {
+    r: B5,
+    g: B5,
+    b: B5,
     unused: B1,
 }
 
@@ -16,12 +16,12 @@ fn main() {
         let mut new = ColorEntry::new();
         new.set_r(entry.r());
         assert_eq!(new.r(), entry.r());
-        new.set_g(entry.g());    
+        new.set_g(entry.g());
         assert_eq!(new.g(), entry.g());
         new.set_b(entry.b());
         assert_eq!(new.b(), entry.b());
         new.set_unused(entry.unused());
-        
+
         assert_eq!(new.r(), entry.r());
         assert_eq!(new.g(), entry.g());
         assert_eq!(new.b(), entry.b());

--- a/tests/20-access-test.rs
+++ b/tests/20-access-test.rs
@@ -12,7 +12,7 @@ use inner::*;
 fn main() {
     let c = ColorEntry::new();
     let _ = c.a();
-    // Notice no error for calling get_b
+    // Notice no error for calling b
     let _ = c.b();
     // Also no error for using default
     let c = ColorEntry::default();

--- a/tests/20-access-test.rs
+++ b/tests/20-access-test.rs
@@ -1,0 +1,19 @@
+mod inner {
+    use modular_bitfield::prelude::*;
+    #[bitfield]
+    #[derive(Copy, Clone, Eq, PartialEq, Default)]
+    pub struct ColorEntry {
+        a: B5,
+        pub(crate) b: B3,
+    }
+}
+use inner::*;
+
+fn main() {
+    let c = ColorEntry::new();
+    let _ = c.a();
+    // Notice no error for calling get_b
+    let _ = c.b();
+    // Also no error for using default
+    let c = ColorEntry::default();
+}

--- a/tests/20-access-test.stderr
+++ b/tests/20-access-test.stderr
@@ -1,0 +1,11 @@
+error[E0624]: associated function `new` is private
+  --> $DIR/20-access-test.rs:13:25
+   |
+13 |     let c = ColorEntry::new();
+   |                         ^^^ private associated function
+
+error[E0624]: associated function `a` is private
+  --> $DIR/20-access-test.rs:14:15
+   |
+14 |     let _ = c.a();
+   |               ^ private associated function

--- a/tests/20-access-test.stderr
+++ b/tests/20-access-test.stderr
@@ -1,9 +1,3 @@
-error[E0624]: associated function `new` is private
-  --> $DIR/20-access-test.rs:13:25
-   |
-13 |     let c = ColorEntry::new();
-   |                         ^^^ private associated function
-
 error[E0624]: associated function `a` is private
   --> $DIR/20-access-test.rs:14:15
    |

--- a/tests/21-raw-identifiers.rs
+++ b/tests/21-raw-identifiers.rs
@@ -1,0 +1,12 @@
+use modular_bitfield::prelude::*;
+#[bitfield]
+struct RawIdentifiers {
+    r#struct: B5,
+    r#bool: B3,
+}
+
+fn main() {
+    let r = RawIdentifiers::new();
+    let _ = r.r#struct();
+    let _ = r.r#bool();
+}

--- a/tests/progress.rs
+++ b/tests/progress.rs
@@ -22,4 +22,6 @@ fn tests() {
     t.pass("tests/17-byte-conversions.rs");
     t.pass("tests/18-within-single-byte.rs");
     t.pass("tests/19-get-spanning-data.rs");
+    t.compile_fail("tests/20-access-test.rs");
+    t.pass("tests/21-raw-identifiers.rs");
 }


### PR DESCRIPTION
This first and foremost adds visibility attributes to the declared getters and setters, and the struct itself. It also adds a small piece of documentation to `new`. Note that `new` and `to_bytes` are never exposed to the other modules, that is up to debate, but I wouldn't want to expose private invariants like that. PS: I think one ought to name the getter simply after the field name without the `get_` prefix, might as well, since this is a breaking change anyway?

Also updated the expected error messages from the testcases to the newest compiler version and formatted touched files.