### PR TITLE
Allow non-power-of-two enums

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -109,7 +109,7 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
 /// assert_eq!(example.a(), true); // `true as u8` is 1
 /// assert_eq!(example.b(), Mode::Awake);
 /// ```
-#[proc_macro_derive(BitfieldSpecifier)]
+#[proc_macro_derive(BitfieldSpecifier, attributes(bits))]
 pub fn bitfield_specifier(input: TokenStream) -> TokenStream {
     bitfield_specifier::generate(input.into()).into()
 }

--- a/tests/08-non-power-of-two.stderr
+++ b/tests/08-non-power-of-two.stderr
@@ -1,4 +1,4 @@
-error: BitfieldSpecifier expected a number of variants which is a power of 2
+error: BitfieldSpecifier expected a number of variants which is a power of 2, specify #[bits = 2] if that was your intent
   --> $DIR/08-non-power-of-two.rs:11:1
    |
 11 | pub enum Bad {

--- a/tests/28-single-bit-enum.rs
+++ b/tests/28-single-bit-enum.rs
@@ -1,0 +1,29 @@
+// Validates that in a degenerate case with a single bit, non-power-of-two enums
+// behave as expected.
+
+use modular_bitfield::error::InvalidBitPattern;
+use modular_bitfield::prelude::*;
+
+#[bitfield]
+pub struct UselessStruct {
+    reserved: B3,
+    field: ForciblyTrue,
+    reserved2: B4,
+}
+
+#[derive(BitfieldSpecifier, Debug, PartialEq)]
+#[bits = 1]
+pub enum ForciblyTrue {
+    True = 1,
+}
+
+fn main() {
+    assert_eq!(std::mem::size_of::<UselessStruct>(), 1);
+
+    // Initialized to all 0 bits.
+    let entry = UselessStruct::new();
+    assert_eq!(entry.field_or_err(), Err(InvalidBitPattern{ invalid_bytes: 0 }));
+
+    let entry = UselessStruct::new().with_field(ForciblyTrue::True);
+    assert_eq!(entry.field_or_err(), Ok(ForciblyTrue::True));
+}

--- a/tests/progress.rs
+++ b/tests/progress.rs
@@ -31,4 +31,5 @@ fn tests() {
     t.pass("tests/25-regression-issue-8.rs");
     t.compile_fail("tests/26-invalid-struct-specifier.rs");
     t.compile_fail("tests/27-invalid-union-specifier.rs");
+    t.pass("tests/28-single-bit-enum.rs");
 }


### PR DESCRIPTION
Fixes #3.

This supports non power of two enums more or less how they're specified in `06-enums`. The return value is an `Result<T, EnumError>` where `EnumError` has a single variant `UnrecognizedValue`. Enums are limited to 32 bits just to make the error type easier.

This PR also splits the `Face` type on the `Specifier` trait into a `GetterReturn` type which specifies the type returned by a getter. For most types it's equivalent to the `Face` type.

I screwed up some of the commits in a merge, but squashed they're good - I can squash them or tease out the Face/GetterReturn split changes into a separate commit. (hence why I haven't autosquashed yet)

There is no way to set a raw value. I was imagining an API like:
```
my_struct.set_small_prime_raw(9); // Maybe even unsafe?
let my_struct = my_struct.with_small_prime_raw(9);
```
but I think that would require `_raw` methods for _every_ field, not just enum fields. Which is fine it's just more methods/compile time.
