### PR TITLE
Implement bitfield structs in structs

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,7 @@
 # 0.9.0 (WIP)
 
+- Add `#[bitfield(specifier = bool)]` parameter with which it now is possible to have bitfield structs automatically also
+  implement the `modular_bitfield::Specifier` trait which makes it possible to have bitfields as fields of bitfields.
 - No longer generates an `unsafe fn from_bytes_unchecked`. Now generates a safe `fn from_bytes` that is basically identical.
   The difference is that we no longer consider bitfields containing invalid bit patterns as invalid since generated getters
   will protect their access anyways.

--- a/impl/src/bitfield.rs
+++ b/impl/src/bitfield.rs
@@ -12,6 +12,10 @@ use syn::{
     spanned::Spanned as _,
     Token,
 };
+use crate::bitfield_attr::{
+    AttributeArgs,
+    Config,
+};
 
 /// Analyzes the given token stream for `#[bitfield]` properties and expands code if valid.
 pub fn analyse_and_expand(args: TokenStream2, input: TokenStream2) -> TokenStream2 {
@@ -27,10 +31,12 @@ pub fn analyse_and_expand(args: TokenStream2, input: TokenStream2) -> TokenStrea
 ///
 /// If the given token stream does not yield a valid `#[bitfield]` specifier.
 fn analyse_and_expand_or_error(
-    _args: TokenStream2,
+    args: TokenStream2,
     input: TokenStream2,
 ) -> Result<TokenStream2> {
     let input = syn::parse::<syn::ItemStruct>(input.into())?;
+    let attrs = syn::parse::<AttributeArgs>(args.into())?;
+    let _config = Config::try_from(attrs)?;
     let bitfield = BitfieldStruct::try_from(input)?;
     Ok(bitfield.expand())
 }

--- a/impl/src/bitfield.rs
+++ b/impl/src/bitfield.rs
@@ -1,8 +1,11 @@
+use crate::bitfield_attr::{
+    AttributeArgs,
+    Config,
+};
 use core::convert::TryFrom;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{
     format_ident,
-    quote,
     quote_spanned,
 };
 use syn::{
@@ -11,10 +14,6 @@ use syn::{
     punctuated::Punctuated,
     spanned::Spanned as _,
     Token,
-};
-use crate::bitfield_attr::{
-    AttributeArgs,
-    Config,
 };
 
 /// Analyzes the given token stream for `#[bitfield]` properties and expands code if valid.
@@ -36,9 +35,9 @@ fn analyse_and_expand_or_error(
 ) -> Result<TokenStream2> {
     let input = syn::parse::<syn::ItemStruct>(input.into())?;
     let attrs = syn::parse::<AttributeArgs>(args.into())?;
-    let _config = Config::try_from(attrs)?;
+    let config = Config::try_from(attrs)?;
     let bitfield = BitfieldStruct::try_from(input)?;
-    Ok(bitfield.expand())
+    Ok(bitfield.expand(&config))
 }
 
 /// Type used to guide analysis and expansion of `#[bitfield]` structs.
@@ -112,11 +111,12 @@ impl BitfieldStruct {
     }
 
     /// Expands the given `#[bitfield]` struct into an actual bitfield definition.
-    pub fn expand(&self) -> TokenStream2 {
+    pub fn expand(&self, config: &Config) -> TokenStream2 {
         let span = self.item_struct.span();
-        let check_multiple_of_8 = self.generate_check_multiple_of_8();
+        let check_multiple_of_8 = self.generate_check_multiple_of_8(config);
         let struct_definition = self.generate_struct();
         let constructor_definition = self.generate_constructor();
+        let specifier_impl = self.generate_specifier_impl(config);
 
         let byte_conversion_impls = self.expand_byte_conversion_impls();
         let getters_and_setters = self.expand_getters_and_setters();
@@ -127,7 +127,49 @@ impl BitfieldStruct {
             #constructor_definition
             #byte_conversion_impls
             #getters_and_setters
+            #specifier_impl
         )
+    }
+
+    /// Expands to the `Specifier` impl for the `#[bitfield]` struct if `specifier = true`.
+    ///
+    /// Otherwise returns `None`.
+    pub fn generate_specifier_impl(&self, config: &Config) -> Option<TokenStream2> {
+        if !config.specifier {
+            return None
+        }
+        let span = self.item_struct.span();
+        let ident = &self.item_struct.ident;
+        let bits = self.generate_bitfield_size();
+        let next_divisible_by_8 = Self::next_divisible_by_8(&bits);
+        Some(quote_spanned!(span =>
+            impl ::modular_bitfield::Specifier for #ident {
+                const BITS: usize = #bits;
+
+                type Bytes = <[(); #next_divisible_by_8] as ::modular_bitfield::private::SpecifierBytes>::Bytes;
+                type InOut = Self;
+
+                #[inline]
+                fn into_bytes(
+                    value: Self::InOut,
+                ) -> ::core::result::Result<Self::Bytes, ::modular_bitfield::error::OutOfBounds> {
+                    ::core::result::Result::Ok(<Self::Bytes>::from_le_bytes(value.bytes))
+                }
+
+                #[inline]
+                fn from_bytes(
+                    bytes: Self::Bytes,
+                ) -> ::core::result::Result<Self::InOut, ::modular_bitfield::error::InvalidBitPattern<Self::Bytes>>
+                {
+                    if bytes > ((0x01 << Self::BITS) - 1) {
+                        return ::core::result::Result::Err(::modular_bitfield::error::InvalidBitPattern::new(bytes))
+                    }
+                    ::core::result::Result::Ok(Self {
+                        bytes: bytes.to_le_bytes(),
+                    })
+                }
+            }
+        ))
     }
 
     /// Generates the expression denoting the sum of all field bit specifier sizes.
@@ -188,17 +230,30 @@ impl BitfieldStruct {
     }
 
     /// Generates the `CheckTotalSizeMultipleOf8` trait implementation to check for correct bitfield sizes.
-    fn generate_check_multiple_of_8(&self) -> TokenStream2 {
+    ///
+    /// Won't generate a check if `#[bitfield(specifier = true)]` is set.
+    fn generate_check_multiple_of_8(&self, config: &Config) -> Option<TokenStream2> {
+        if config.specifier {
+            return None
+        }
         let span = self.item_struct.span();
         let ident = &self.item_struct.ident;
         let size = self.generate_bitfield_size();
-        quote_spanned!(span=>
+        Some(quote_spanned!(span=>
             const _: () = {
                 impl ::modular_bitfield::private::checks::CheckTotalSizeMultipleOf8 for #ident {
                     type Size = ::modular_bitfield::private::checks::TotalSize<[(); #size % 8usize]>;
                 }
             };
-        )
+        ))
+    }
+
+    /// Returns a token stream representing the next greater value divisible by 8.
+    fn next_divisible_by_8(value: &TokenStream2) -> TokenStream2 {
+        let span = value.span();
+        quote_spanned!(span=> {
+            (((#value - 1) / 8) + 1) * 8
+        })
     }
 
     /// Generates the actual item struct definition for the `#[bitfield]`.
@@ -211,12 +266,13 @@ impl BitfieldStruct {
         let vis = &self.item_struct.vis;
         let ident = &self.item_struct.ident;
         let size = self.generate_bitfield_size();
+        let next_divisible_by_8 = Self::next_divisible_by_8(&size);
         quote_spanned!(span=>
             #( #attrs )*
             #[repr(transparent)]
             #vis struct #ident
             {
-                bytes: [::core::primitive::u8; #size / 8usize],
+                bytes: [::core::primitive::u8; #next_divisible_by_8 / 8usize],
             }
         )
     }
@@ -226,13 +282,14 @@ impl BitfieldStruct {
         let span = self.item_struct.span();
         let ident = &self.item_struct.ident;
         let size = self.generate_bitfield_size();
+        let next_divisible_by_8 = Self::next_divisible_by_8(&size);
         quote_spanned!(span=>
             impl #ident
             {
                 /// Returns an instance with zero initialized data
                 pub const fn new() -> Self {
                     Self {
-                        bytes: [0u8; #size / 8usize],
+                        bytes: [0u8; #next_divisible_by_8 / 8usize],
                     }
                 }
             }
@@ -241,10 +298,11 @@ impl BitfieldStruct {
 
     /// Generates routines to allow conversion from and to bytes for the `#[bitfield]` struct.
     fn expand_byte_conversion_impls(&self) -> TokenStream2 {
+        let span = self.item_struct.span();
         let ident = &self.item_struct.ident;
         let size = self.generate_bitfield_size();
-
-        quote! {
+        let next_divisible_by_8 = Self::next_divisible_by_8(&size);
+        quote_spanned!(span=>
             impl #ident {
                 /// Returns the underlying bits.
                 ///
@@ -253,17 +311,17 @@ impl BitfieldStruct {
                 /// The returned byte array is layed out in the same way as described
                 /// [here](https://docs.rs/modular-bitfield/#generated-structure).
                 #[inline]
-                pub const fn as_bytes(&self) -> &[::core::primitive::u8; #size / 8usize] {
+                pub const fn as_bytes(&self) -> &[::core::primitive::u8; #next_divisible_by_8 / 8usize] {
                     &self.bytes
                 }
 
                 /// Converts the given bytes directly into the bitfield struct.
                 #[inline]
-                pub const fn from_bytes(bytes: [::core::primitive::u8; #size / 8usize]) -> Self {
+                pub const fn from_bytes(bytes: [::core::primitive::u8; #next_divisible_by_8 / 8usize]) -> Self {
                     Self { bytes }
                 }
             }
-        }
+        )
     }
 
     /// Generates code to check for the bit size arguments of bitfields.

--- a/impl/src/bitfield_attr.rs
+++ b/impl/src/bitfield_attr.rs
@@ -1,0 +1,103 @@
+use crate::errors::CombineError;
+use core::convert::TryFrom;
+use proc_macro2::Span;
+use syn::spanned::Spanned;
+
+pub struct Config {
+    pub specifier: bool,
+}
+
+#[derive(Default)]
+pub struct ConfigBuilder {
+    specifier: Option<(bool, Span)>,
+}
+
+impl ConfigBuilder {
+    /// Sets the specifier to the given value.
+    ///
+    /// # Errors
+    ///
+    /// If the specifier has already been set.
+    pub fn specifier(&mut self, value: bool, span: Span) -> Result<(), syn::Error> {
+        match self.specifier {
+            Some((specifier, previous)) => {
+                return Err(format_err!(
+                    span,
+                    "encountered duplicate specifier parameter: duplicate set to {:?}",
+                    specifier
+                )
+                .into_combine(format_err!(previous, "previous specifier parameter here")))
+            }
+            None => self.specifier = Some((value, span)),
+        }
+        Ok(())
+    }
+
+    /// Converts the config builder into a config.
+    pub fn into_config(self) -> Config {
+        Config {
+            specifier: self.specifier.map(|(value, _)| value).unwrap_or(false),
+        }
+    }
+}
+
+fn unsupported_argument<T>(arg: T) -> syn::Error
+where
+    T: Spanned,
+{
+    format_err!(arg, "encountered unsupported #[bitfield] attribute")
+}
+
+pub struct AttributeArgs {
+    args: syn::AttributeArgs,
+}
+
+impl syn::parse::Parse for AttributeArgs {
+    fn parse(input: syn::parse::ParseStream) -> Result<Self, syn::Error> {
+        let punctuated =
+            <syn::punctuated::Punctuated<_, syn::Token![,]>>::parse_terminated(input)?;
+        Ok(Self {
+            args: punctuated.into_iter().collect::<Vec<_>>(),
+        })
+    }
+}
+
+impl TryFrom<AttributeArgs> for Config {
+    type Error = syn::Error;
+
+    fn try_from(attribute_args: AttributeArgs) -> Result<Self, Self::Error> {
+        let mut builder = ConfigBuilder::default();
+        let AttributeArgs { args } = attribute_args;
+        for nested_meta in args {
+            match nested_meta {
+                syn::NestedMeta::Meta(meta) => {
+                    match meta {
+                        syn::Meta::NameValue(name_value) => {
+                            if name_value.path.is_ident("specifier") {
+                                match name_value.lit {
+                                syn::Lit::Bool(lit_bool) => {
+                                    builder.specifier(lit_bool.value, lit_bool.span())?;
+                                }
+                                invalid => {
+                                    return Err(format_err!(
+                                        invalid,
+                                        "encountered invalid value argument for #[bitfield] specifier parameter",
+                                    ))
+                                }
+                            }
+                            }
+                        }
+                        unsupported => return Err(unsupported_argument(unsupported)),
+                    }
+                }
+                unsupported => {
+                    return Err(format_err!(
+                        unsupported,
+                        "encountered unsupported #[bitfield] attribute"
+                    ))
+                }
+            }
+        }
+        Ok(builder.into_config())
+    }
+}

--- a/impl/src/errors.rs
+++ b/impl/src/errors.rs
@@ -48,3 +48,14 @@ macro_rules! format_err {
         )
     }}
 }
+
+pub trait CombineError {
+    fn into_combine(self, another: syn::Error) -> Self;
+}
+
+impl CombineError for syn::Error {
+    fn into_combine(mut self, another: syn::Error) -> Self {
+        self.combine(another);
+        self
+    }
+}

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -6,9 +6,9 @@ extern crate proc_macro;
 #[macro_use]
 mod errors;
 mod bitfield;
+mod bitfield_attr;
 mod bitfield_specifier;
 mod define_specifiers;
-mod bitfield_attr;
 
 use proc_macro::TokenStream;
 

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -72,7 +72,6 @@ pub fn define_specifiers(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
-    // bitfield::generate(args.into(), input.into()).into()
     bitfield::analyse_and_expand(args.into(), input.into()).into()
 }
 

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -8,6 +8,7 @@ mod errors;
 mod bitfield;
 mod bitfield_specifier;
 mod define_specifiers;
+mod bitfield_attr;
 
 use proc_macro::TokenStream;
 

--- a/tests/29-struct-in-struct.rs
+++ b/tests/29-struct-in-struct.rs
@@ -19,5 +19,8 @@ fn main() {
     assert_eq!(base.header(), Header::new());
     let h = Header::new().with_a(1).with_b(2);
     base.set_header(h);
-    assert_eq!(base.header(), h);
+    let h2 = base.header();
+    assert_eq!(h2, h);
+    assert_eq!(h2.a(), 1);
+    assert_eq!(h2.b(), 2);
 }

--- a/tests/29-struct-in-struct.rs
+++ b/tests/29-struct-in-struct.rs
@@ -1,0 +1,21 @@
+use modular_bitfield::prelude::*;
+
+#[bitfield(specifier = true)]
+pub struct Header {
+    a: B2,
+    b: B3,
+}
+
+#[bitfield]
+pub struct Base {
+    pub header: Header,
+    pub rest: B3,
+}
+
+fn main() {
+    let base = Base::new();
+    assert_eq!(base.header(), Header::new());
+    let h = Header::new().with_a(1).with_b(2);
+    base.set_header(h);
+    assert_eq!(base.header(), h);
+}

--- a/tests/29-struct-in-struct.rs
+++ b/tests/29-struct-in-struct.rs
@@ -1,19 +1,21 @@
 use modular_bitfield::prelude::*;
 
 #[bitfield(specifier = true)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct Header {
     a: B2,
     b: B3,
 }
 
 #[bitfield]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Base {
     pub header: Header,
     pub rest: B3,
 }
 
 fn main() {
-    let base = Base::new();
+    let mut base = Base::new();
     assert_eq!(base.header(), Header::new());
     let h = Header::new().with_a(1).with_b(2);
     base.set_header(h);

--- a/tests/progress.rs
+++ b/tests/progress.rs
@@ -32,4 +32,5 @@ fn tests() {
     t.compile_fail("tests/26-invalid-struct-specifier.rs");
     t.compile_fail("tests/27-invalid-union-specifier.rs");
     t.pass("tests/28-single-bit-enum.rs");
+    t.pass("tests/29-struct-in-struct.rs");
 }


### PR DESCRIPTION
Implements https://github.com/Robbepop/modular-bitfield/issues/5.

This now works:

```rust
use modular_bitfield::prelude::*;

#[bitfield(specifier = true)]
#[derive(Debug, PartialEq, Eq, Copy, Clone)]
pub struct Header {
    a: B2,
    b: B3,
}

#[bitfield]
#[derive(Debug, PartialEq, Eq)]
pub struct Base {
    pub header: Header,
    pub rest: B3,
}

fn main() {
    let mut base = Base::new();
    assert_eq!(base.header(), Header::new());
    let h = Header::new().with_a(1).with_b(2);
    base.set_header(h);
    assert_eq!(base.header(), h);
    assert_eq!(h2.a(), 1);
    assert_eq!(h2.b(), 2);
}
```