### PR TITLE
fixup! [impl] silence most repetitive dead_code warnings

### DIFF
--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -74,6 +74,7 @@ impl BitfieldStruct {
                 type InOut = Self;
 
                 #[inline]
+                #[allow(dead_code)]
                 fn into_bytes(
                     value: Self::InOut,
                 ) -> ::core::result::Result<Self::Bytes, ::modular_bitfield::error::OutOfBounds> {
@@ -85,6 +86,7 @@ impl BitfieldStruct {
                 }
 
                 #[inline]
+                #[allow(dead_code)]
                 fn from_bytes(
                     bytes: Self::Bytes,
                 ) -> ::core::result::Result<Self::InOut, ::modular_bitfield::error::InvalidBitPattern<Self::Bytes>>
@@ -412,6 +414,7 @@ impl BitfieldStruct {
                     /// Converts the given bytes directly into the bitfield struct.
                     #[inline]
                     #[allow(clippy::identity_op)]
+                    #[allow(dead_code)]
                     pub const fn from_bytes(bytes: [::core::primitive::u8; #next_divisible_by_8 / 8usize]) -> Self {
                         Self { bytes }
                     }
@@ -426,6 +429,7 @@ impl BitfieldStruct {
                     /// If the given bytes contain bits at positions that are undefined for `Self`.
                     #[inline]
                     #[allow(clippy::identity_op)]
+                    #[allow(dead_code)]
                     pub fn from_bytes(
                         bytes: [::core::primitive::u8; #next_divisible_by_8 / 8usize]
                     ) -> ::core::result::Result<Self, ::modular_bitfield::error::OutOfBounds> {
@@ -447,6 +451,7 @@ impl BitfieldStruct {
                 /// [here](https://docs.rs/modular-bitfield/#generated-structure).
                 #[inline]
                 #[allow(clippy::identity_op)]
+                #[allow(dead_code)]
                 pub const fn into_bytes(self) -> [::core::primitive::u8; #next_divisible_by_8 / 8usize] {
                     self.bytes
                 }
@@ -531,6 +536,7 @@ impl BitfieldStruct {
         let getters = quote_spanned!(span=>
             #[doc = #getter_docs]
             #[inline]
+            #[allow(dead_code)]
             #( #retained_attrs )*
             #vis fn #get_ident(&self) -> <#ty as ::modular_bitfield::Specifier>::InOut {
                 self.#get_checked_ident().expect(#get_assert_msg)


### PR DESCRIPTION
Adds a bunch more dead_code warnings.

With this playground:
```
//#![allow(dead_code, unused_attributes, unused_imports)]

use modular_bitfield::prelude::*;

#[bitfield]
struct MyFourBytes {
    a: B1,
    b: B3,
    c: B4,
    d: B24,
}

fn main() {
    let x = MyFourBytes::new();
    println!("{}", x.a());
}
```
I get no warnings.

This may affect #56, since it seemed like the issue there was more about silencing warnings than reducing generated code. (I won't say the magic words to make it auto-close, though)
