### PR TITLE
Add initial support for setting endian with BitfieldSpecifier.

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -432,7 +432,7 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
 /// assert_eq!(slot.to(), 15);
 /// assert!(!slot.expired());
 /// ```
-#[proc_macro_derive(BitfieldSpecifier, attributes(bits))]
+#[proc_macro_derive(BitfieldSpecifier, attributes(bits, endian))]
 pub fn bitfield_specifier(input: TokenStream) -> TokenStream {
     bitfield_specifier::generate(input.into()).into()
 }


### PR DESCRIPTION
Hi,

I'm a beginner with rust (this is day 4). I very much like how easy it was to parse binary data with this library. I however needed some Endian support.

I have this working on the BitfieldSpecifier macro. For example:

```rust
#[derive(BitfieldSpecifier, Debug)]
#[bits = 16]
#[endian = 1]
pub enum QClass {
    Reserved = 0,   // [RFC6895]
    Internet = 1,   // (IN)   [RFC1035]
    // ...
}

#[bitfield(bits = 32)] // Excluding the variable length qname
#[derive(Copy, Clone, Debug)]
pub struct Question {
    qtype: u16,  // TODO enum 0x0001 A record
    qclass: QClass,
}
```

Notice the `#[endian = 1]` it changes the `BitfieldSpecifier` to pass things though to_be and from_be.

Does this approach make sense? If so, I'd like to clean it up, add tests, write docs, and extend it to `bitfield`.