### PR TITLE
Bitfields with algebraic data types

### DIFF
--- a/impl/src/adt_specifier.rs
+++ b/impl/src/adt_specifier.rs
@@ -1,0 +1,232 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote_spanned;
+use syn::{punctuated::Punctuated, spanned::Spanned as _};
+
+use crate::bitfield_specifier;
+
+pub(super) fn generate_adt(input: syn::ItemEnum) -> syn::Result<TokenStream2> {
+    let span = input.span();
+    let enum_ident = &input.ident;
+
+    let maybe_tag_type = input
+        .attrs
+        .iter()
+        .filter(|attr| attr.path.is_ident("tag"))
+        .fold(Ok(None), |acc, attr| {
+            if acc?.is_some() {
+                return Err(format_err_spanned!(
+                    attr,
+                    "More than one 'tag' attribute is not permitted",
+                ));
+            }
+            Ok(Some(attr.parse_args::<syn::Type>()?))
+        })?;
+
+    let (tag, tag_code) = match maybe_tag_type {
+        Some(ty) => (quote_spanned!(span=> #ty), quote_spanned!(span=> )),
+        None => {
+            let tag = syn::Ident::new(
+                &format!("__Bf_{}_Tag", input.ident),
+                proc_macro2::Span::mixed_site(),
+            );
+            let mut tag_enum = input.clone();
+            tag_enum.vis = syn::Visibility::Inherited;
+            tag_enum.ident = tag.clone();
+            tag_enum
+                .variants
+                .iter_mut()
+                .for_each(|var| var.fields = syn::Fields::Unit);
+            let tag_specifier = bitfield_specifier::generate_enum(tag_enum.clone())?;
+            // Attributes like "bits" are only used by generate_enum
+            tag_enum.attrs.clear();
+            (
+                quote_spanned!(span=> #tag),
+                quote_spanned!(span=> #tag_enum #tag_specifier),
+            )
+        }
+    };
+
+    let tag_bits = quote_spanned!(span=>
+        <#tag as ::modular_bitfield::Specifier>::BITS
+    );
+    let bits = input
+        .variants
+        .iter()
+        .filter_map(|variant| match &variant.fields {
+            syn::Fields::Named(fs) => Some(fs.named.iter()),
+            syn::Fields::Unnamed(fs) => Some(fs.unnamed.iter()),
+            syn::Fields::Unit => None,
+        })
+        .map(|fields| {
+            fields
+                .map(|field| {
+                    let span = field.span();
+                    let ty = &field.ty;
+                    quote_spanned!(span=>
+                        <#ty as ::modular_bitfield::Specifier>::BITS
+                    )
+                })
+                .fold(quote_spanned!(span=> #tag_bits), |lhs, rhs| {
+                    quote_spanned!(span =>
+                        #lhs + #rhs
+                    )
+                })
+        })
+        .reduce(|arm1, arm2| {
+            quote_spanned!(span=>
+                ::modular_bitfield::private::const_max(#arm1, #arm2)
+            )
+        });
+
+    let next_divisible_by_8 = quote_spanned!(span=> (((#bits - 1) / 8) + 1) * 8);
+
+    let mut offset = Punctuated::<syn::Expr, syn::Token![+]>::new();
+    offset.push(syn::parse::<syn::Expr>(tag_bits.into())?);
+
+    let from_bytes_arms = input.variants.iter().map(|variant| {
+        let ident = &variant.ident;
+        let span = variant.span();
+
+        let mut offset = offset.clone();
+        let data_from_bytes = variant.fields.iter().enumerate().map(|(i, field)| {
+            let ty = &field.ty;
+            let temp = temp_id(i);
+            let tokens = quote_spanned! {span=>
+                let __bf_read: <#ty as ::modular_bitfield::Specifier>::Bytes = {
+                    ::modular_bitfield::private::read_specifier::<#ty>(&array[..], #offset)
+                };
+                let #temp = <#ty as ::modular_bitfield::Specifier>::from_bytes(__bf_read)
+                    .map_err(|_| ::modular_bitfield::error::InvalidBitPattern::new(bytes))?;
+            };
+            offset.push(syn::parse_quote! { <#ty as ::modular_bitfield::Specifier>::BITS });
+            tokens
+        });
+
+        let construct = constructor(variant);
+        quote_spanned!(span=>
+            #tag::#ident => {
+                #( #data_from_bytes )*
+                Ok(#enum_ident::#construct)
+            }
+        )
+    });
+
+    let into_bytes_arms = input.variants.iter().map(|variant| {
+        let span = variant.span();
+        let ident = &variant.ident;
+        let construct = constructor(variant);
+
+        let write_tag = check_bounds_and_write(
+            span,
+            quote_spanned!(span=> #tag),
+            quote_spanned!(span=> #tag::#ident),
+            quote_spanned!(span=> 0usize),
+        );
+
+        let mut offset = offset.clone();
+        let data_to_bytes = variant.fields.iter().enumerate().map(|(i, field)| {
+            let ty = &field.ty;
+            let temp = temp_id(i);
+            let tokens = check_bounds_and_write(
+                span,
+                quote_spanned!(span=> #ty),
+                quote_spanned!(span=> #temp),
+                quote_spanned!(span=> #offset),
+            );
+            offset
+                .push(syn::parse_quote! { <#ty as ::modular_bitfield::Specifier>::BITS });
+            tokens
+        });
+
+        quote_spanned! {span=> #enum_ident::#construct => {
+            let mut __bf_bytes = [0u8; #next_divisible_by_8 / 8usize];
+            #write_tag
+            #( #data_to_bytes )*
+            ::core::result::Result::Ok(
+                <[(); #next_divisible_by_8] as ::modular_bitfield::private::ArrayBytesConversion>::array_into_bytes(__bf_bytes)
+            )
+        }}
+    });
+
+    Ok(quote_spanned!(span=>
+        #tag_code
+        #[allow(clippy::identity_op)]
+        const _: () = {
+            impl ::modular_bitfield::private::checks::CheckSpecifierHasAtMost128Bits for #enum_ident {
+                type CheckType = [(); (#bits <= 128) as ::core::primitive::usize];
+            }
+        };
+        impl ::modular_bitfield::Specifier for #enum_ident {
+            const BITS: usize = #bits;
+            type Bytes = <[(); #bits] as ::modular_bitfield::private::SpecifierBytes>::Bytes;
+            type InOut = Self;
+
+            #[inline]
+            fn into_bytes(input: Self::InOut) -> ::core::result::Result<Self::Bytes, ::modular_bitfield::error::OutOfBounds> {
+                match input {
+                    #( #into_bytes_arms ),*
+                }
+            }
+
+            #[inline]
+            fn from_bytes(bytes: Self::Bytes) -> ::core::result::Result<Self::InOut, ::modular_bitfield::error::InvalidBitPattern<Self::Bytes>> {
+                let array = <[(); #next_divisible_by_8] as ::modular_bitfield::private::ArrayBytesConversion>::bytes_into_array(bytes);
+                let __tag_read: <#tag as ::modular_bitfield::Specifier>::Bytes = {
+                    ::modular_bitfield::private::read_specifier::<#tag>(&array[..], 0)
+                };
+                let tag = <#tag as ::modular_bitfield::Specifier>::from_bytes(__tag_read)
+                    .map_err(|_| ::modular_bitfield::error::InvalidBitPattern::new(bytes))?;
+                match tag {
+                    #( #from_bytes_arms ),*
+                    #[allow(unreachable_patterns)]
+                    _ => ::core::result::Result::Err(
+                        ::modular_bitfield::error::InvalidBitPattern::new(bytes))
+                }
+            }
+        }
+    ))
+}
+fn temp_id(i: usize) -> syn::Ident {
+    syn::Ident::new(&format!("__bf_temp_{}", i), proc_macro2::Span::mixed_site())
+}
+fn constructor(variant: &syn::Variant) -> TokenStream2 {
+    let span = variant.span();
+    let ident = &variant.ident;
+    let args = variant.fields.iter().enumerate().map(|(i, field)| {
+        let temp = temp_id(i);
+        match &field.ident {
+            None => quote_spanned!(span=> #temp),
+            Some(id) => quote_spanned!(span=> #id: #temp),
+        }
+    });
+    match variant.fields {
+        syn::Fields::Named(_) => quote_spanned!(span=> #ident{#( #args ),*}),
+        syn::Fields::Unnamed(_) => quote_spanned!(span=> #ident(#( #args ),*)),
+        syn::Fields::Unit => quote_spanned!(span=> #ident),
+    }
+}
+
+fn check_bounds_and_write(
+    span: proc_macro2::Span,
+    ty: TokenStream2,
+    value: TokenStream2,
+    offset: TokenStream2,
+) -> TokenStream2 {
+    quote_spanned! {span=>
+        let __bf_base_bits: ::core::primitive::usize = 8usize * ::core::mem::size_of::<<#ty as ::modular_bitfield::Specifier>::Bytes>();
+        let __bf_max_value: <#ty as ::modular_bitfield::Specifier>::Bytes = {
+            !0 >> (__bf_base_bits - <#ty as ::modular_bitfield::Specifier>::BITS)
+        };
+        let __bf_spec_bits: ::core::primitive::usize = <#ty as ::modular_bitfield::Specifier>::BITS;
+        let __bf_raw_val: <#ty as ::modular_bitfield::Specifier>::Bytes = {
+            <#ty as ::modular_bitfield::Specifier>::into_bytes(#value)
+        }?;
+        // We compare base bits with spec bits to drop this condition
+        // if there cannot be invalid inputs.
+        if !(__bf_base_bits == __bf_spec_bits || __bf_raw_val <= __bf_max_value) {
+            return ::core::result::Result::Err(::modular_bitfield::error::OutOfBounds)
+        }
+        ::modular_bitfield::private::write_specifier::<#ty>(
+            &mut __bf_bytes, #offset, __bf_raw_val);
+    }
+}

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -5,6 +5,7 @@ extern crate proc_macro;
 
 #[macro_use]
 mod errors;
+mod adt_specifier;
 mod bitfield;
 mod bitfield_specifier;
 mod define_specifiers;
@@ -432,7 +433,7 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
 /// assert_eq!(slot.to(), 15);
 /// assert!(!slot.expired());
 /// ```
-#[proc_macro_derive(BitfieldSpecifier, attributes(bits))]
+#[proc_macro_derive(BitfieldSpecifier, attributes(bits, tag))]
 pub fn bitfield_specifier(input: TokenStream) -> TokenStream {
     bitfield_specifier::generate(input.into()).into()
 }

--- a/src/private/mod.rs
+++ b/src/private/mod.rs
@@ -13,6 +13,7 @@ pub use self::{
     proc::{
         read_specifier,
         write_specifier,
+        const_max,
     },
     push_pop::{
         PopBuffer,

--- a/src/private/proc.rs
+++ b/src/private/proc.rs
@@ -113,3 +113,8 @@ pub fn write_specifier<T>(
         }
     }
 }
+
+#[doc(hidden)]
+pub const fn const_max(a: usize, b: usize) -> usize {
+    if a > b { a } else { b }
+}

--- a/tests/derive-bitfield-specifier/adt_errors.rs
+++ b/tests/derive-bitfield-specifier/adt_errors.rs
@@ -1,0 +1,26 @@
+use modular_bitfield::prelude::*;
+
+#[derive(BitfieldSpecifier)]
+pub enum Two {
+    Zero,
+    One,
+    Two,
+    Three,
+}
+
+#[derive(BitfieldSpecifier)]
+#[bits = 1]
+pub enum OutOfRange {
+    First(Two, Two),
+    Second(Two),
+    OutOfRange,
+}
+
+#[derive(BitfieldSpecifier)]
+pub enum NonPowerOf2 {
+    First(Two, Two),
+    Second(Two),
+    Third,
+}
+
+fn main() {}

--- a/tests/derive-bitfield-specifier/adt_errors.stderr
+++ b/tests/derive-bitfield-specifier/adt_errors.stderr
@@ -1,0 +1,17 @@
+error: BitfieldSpecifier expected a number of variants which is a power of 2, specify #[bits = 2] if that was your intent
+  --> tests/derive-bitfield-specifier/adt_errors.rs:20:5
+   |
+20 | pub enum NonPowerOf2 {
+   |     ^^^^
+
+error[E0277]: the trait bound `False: DiscriminantInRange` is not satisfied
+   --> tests/derive-bitfield-specifier/adt_errors.rs:16:5
+    |
+16  |     OutOfRange,
+    |     ^^^^^^^^^^ the trait `DiscriminantInRange` is not implemented for `False`
+    |
+note: required by a bound in `CheckDiscriminantInRange`
+   --> src/private/checks.rs
+    |
+    |     <Self::CheckType as DispatchTrueFalse>::Out: DiscriminantInRange,
+    |                                                  ^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckDiscriminantInRange`

--- a/tests/derive-bitfield-specifier/adt_tag_missing.rs
+++ b/tests/derive-bitfield-specifier/adt_tag_missing.rs
@@ -1,0 +1,28 @@
+use modular_bitfield::prelude::*;
+
+#[derive(BitfieldSpecifier)]
+pub enum Two {
+    Zero,
+    One,
+    Two,
+    Three,
+}
+
+#[derive(BitfieldSpecifier)]
+pub enum Tag {
+    First,
+    Second,
+    ThisIsOk,
+    AlsoOk,
+}
+
+#[derive(BitfieldSpecifier)]
+#[tag(Tag)]
+pub enum TagMissing {
+    First(Two, Two),
+    Second(Two),
+    Third,
+    Fourth,
+}
+
+fn main() {}

--- a/tests/derive-bitfield-specifier/adt_tag_missing.stderr
+++ b/tests/derive-bitfield-specifier/adt_tag_missing.stderr
@@ -1,0 +1,17 @@
+error[E0599]: no variant or associated item named `Third` found for enum `Tag` in the current scope
+  --> tests/derive-bitfield-specifier/adt_tag_missing.rs:24:5
+   |
+12 | pub enum Tag {
+   | ------------ variant or associated item `Third` not found here
+...
+24 |     Third,
+   |     ^^^^^ variant or associated item not found in `Tag`
+
+error[E0599]: no variant or associated item named `Fourth` found for enum `Tag` in the current scope
+  --> tests/derive-bitfield-specifier/adt_tag_missing.rs:25:5
+   |
+12 | pub enum Tag {
+   | ------------ variant or associated item `Fourth` not found here
+...
+25 |     Fourth,
+   |     ^^^^^^ variant or associated item not found in `Tag`

--- a/tests/derive-bitfield-specifier/adts.rs
+++ b/tests/derive-bitfield-specifier/adts.rs
@@ -1,0 +1,124 @@
+use modular_bitfield::error::InvalidBitPattern;
+use modular_bitfield::prelude::*;
+
+#[derive(BitfieldSpecifier, Debug, PartialEq)]
+pub enum Two {
+    Zero,
+    One,
+    Two,
+    Three,
+}
+#[derive(BitfieldSpecifier, Debug, PartialEq)]
+#[bits = 4]
+pub enum Four {
+    Zero = 0,
+    Fifteen = 15,
+}
+#[derive(BitfieldSpecifier, Debug, PartialEq)]
+#[bits = 5]
+pub enum Five {
+    Zero = 0,
+    ThirtyOne = 31,
+}
+
+#[derive(BitfieldSpecifier, Debug, PartialEq)]
+#[bits = 2]
+pub enum SimpleAdt {
+    First(Two, Four),
+    Second(Two),
+    Third,
+    Fourth,
+}
+
+#[bitfield]
+#[derive(Debug, PartialEq)]
+pub struct SimpleAdtBitfield {
+    adt: SimpleAdt,
+}
+
+#[derive(BitfieldSpecifier, Debug, PartialEq)]
+pub enum NestedAdt {
+    This(SimpleAdt, Two),
+    That { foo: Two, bar: Four },
+}
+
+#[bitfield(filled = false)]
+pub struct NestedAdtBitfield {
+    adt: NestedAdt,
+}
+
+#[bitfield(filled = false)]
+#[derive(BitfieldSpecifier, Debug, PartialEq, Clone, Copy)]
+pub struct RegularBf {
+    first: B2,
+    second: B5,
+}
+
+#[derive(BitfieldSpecifier, Debug, PartialEq)]
+pub enum AdtWithBf {
+    Has(RegularBf),
+    Missing,
+}
+
+#[bitfield]
+pub struct AdtWithBfBitfield {
+    adt: AdtWithBf,
+}
+
+#[derive(BitfieldSpecifier)]
+#[bits = 2]
+pub enum Tags {
+    Unused = 0,
+    Has = 0b01,
+    Missing = 0b10,
+}
+
+#[derive(BitfieldSpecifier, Debug, PartialEq)]
+#[tag(Tags)]
+pub enum Tagged {
+    Has(RegularBf),
+    Missing,
+}
+
+#[bitfield(filled = false)]
+pub struct TaggedBitfield {
+    adt: Tagged,
+}
+
+fn main() {
+    assert_eq!(std::mem::size_of::<SimpleAdtBitfield>(), 1);
+    let mut simple = SimpleAdtBitfield::new();
+    assert_eq!(simple.adt(), SimpleAdt::First(Two::Zero, Four::Zero));
+    simple.set_adt(SimpleAdt::Second(Two::Three));
+    assert_eq!(simple.adt(), SimpleAdt::Second(Two::Three));
+    let fail = SimpleAdtBitfield::from_bytes([0x30]);
+    assert_eq!(fail.adt_or_err(), Err(InvalidBitPattern::new(0x30u8)));
+
+    assert_eq!(std::mem::size_of::<NestedAdtBitfield>(), 2);
+    let mut nested = NestedAdtBitfield::new();
+    assert_eq!(
+        nested.adt(),
+        NestedAdt::This(SimpleAdt::First(Two::Zero, Four::Zero), Two::Zero)
+    );
+    nested.set_adt(NestedAdt::That {
+        foo: Two::One,
+        bar: Four::Fifteen,
+    });
+    assert_eq!(
+        nested.adt(),
+        NestedAdt::That {
+            foo: Two::One,
+            bar: Four::Fifteen
+        }
+    );
+
+    let inner = RegularBf::from_bytes([0b0111_1111]).unwrap();
+    let outer = AdtWithBfBitfield::from_bytes([0b1111_1110]);
+    assert_eq!(outer.adt(), AdtWithBf::Has(inner));
+
+    let mut tagged = TaggedBitfield::from_bytes([0, 0]).unwrap();
+    assert_eq!(tagged.adt_or_err(), Err(InvalidBitPattern::new(0u16)));
+    tagged.set_adt(Tagged::Has(inner));
+    assert_eq!(tagged.adt(), Tagged::Has(inner));
+    assert_eq!(tagged.bytes, [0b1111_1101, 0b1]);
+}

--- a/tests/progress.rs
+++ b/tests/progress.rs
@@ -33,6 +33,9 @@ fn tests() {
     t.pass("tests/derive-bitfield-specifier/07-optional-discriminant.rs");
     t.compile_fail("tests/derive-bitfield-specifier/08-non-power-of-two.rs");
     t.compile_fail("tests/derive-bitfield-specifier/09-variant-out-of-range.rs");
+    t.pass("tests/derive-bitfield-specifier/adts.rs");
+    t.compile_fail("tests/derive-bitfield-specifier/adt_errors.rs");
+    t.compile_fail("tests/derive-bitfield-specifier/adt_tag_missing.rs");
 
     // Tests for regressions found in published versions:
     t.pass("tests/regressions/no-implicit-prelude.rs");


### PR DESCRIPTION
I've come up with a basic implementation of `#[derive(BitfieldSpecifier)]` that works on struct-like enum variants, that is, algebraic data types. It stores a discriminant, which determines the enum variant and the format of the rest of the data.

In terms of API, storing this kind of enum in a bitfield makes the bitfield's getter return the enum type as written. The [derive()] also allows the user to choose the bit pattern of the discriminants by supplying a second, plain enum with members of the same names (specifying them in original enum isn't stable syntax).

One limitation is that the discriminant bits are always before the data.

What do you think?

(I admit that the code isn't the cleanest, I'm pretty new to proc macros. I also had some issues with formatting differences in rustfmt and compiler errors in the test, I'm not sure if it's because of a different compiler version or what.)