### PR TITLE
Ignore unused struct methods

### DIFF
--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -328,6 +328,7 @@ impl BitfieldStruct {
             {
                 /// Returns an instance with zero initialized data.
                 #[allow(clippy::identity_op)]
+                #[allow(dead_code)]
                 pub const fn new() -> Self {
                     Self {
                         bytes: [0u8; #next_divisible_by_8 / 8usize],
@@ -412,6 +413,7 @@ impl BitfieldStruct {
                     /// Converts the given bytes directly into the bitfield struct.
                     #[inline]
                     #[allow(clippy::identity_op)]
+                    #[allow(dead_code)]
                     pub const fn from_bytes(bytes: [::core::primitive::u8; #next_divisible_by_8 / 8usize]) -> Self {
                         Self { bytes }
                     }
@@ -426,6 +428,7 @@ impl BitfieldStruct {
                     /// If the given bytes contain bits at positions that are undefined for `Self`.
                     #[inline]
                     #[allow(clippy::identity_op)]
+                    #[allow(dead_code)]
                     pub fn from_bytes(
                         bytes: [::core::primitive::u8; #next_divisible_by_8 / 8usize]
                     ) -> ::core::result::Result<Self, ::modular_bitfield::error::OutOfBounds> {
@@ -447,6 +450,7 @@ impl BitfieldStruct {
                 /// [here](https://docs.rs/modular-bitfield/#generated-structure).
                 #[inline]
                 #[allow(clippy::identity_op)]
+                #[allow(dead_code)]
                 pub const fn into_bytes(self) -> [::core::primitive::u8; #next_divisible_by_8 / 8usize] {
                     self.bytes
                 }

--- a/tests/04-multiple-of-8bits.stderr
+++ b/tests/04-multiple-of-8bits.stderr
@@ -1,10 +1,17 @@
-error[E0277]: the trait bound `modular_bitfield::private::checks::SevenMod8: modular_bitfield::private::checks::TotalSizeIsMultipleOfEightBits` is not satisfied
-  --> $DIR/04-multiple-of-8bits.rs:54:1
+error[E0277]: the trait bound `SevenMod8: TotalSizeIsMultipleOfEightBits` is not satisfied
+  --> tests/04-multiple-of-8bits.rs:54:1
    |
-54 | pub struct NotQuiteFourBytes {
-   | ^^^ the trait `modular_bitfield::private::checks::TotalSizeIsMultipleOfEightBits` is not implemented for `modular_bitfield::private::checks::SevenMod8`
+54 | / pub struct NotQuiteFourBytes {
+55 | |     a: A,
+56 | |     b: B,
+57 | |     c: C,
+58 | |     d: D,
+59 | | }
+   | |_^ the trait `TotalSizeIsMultipleOfEightBits` is not implemented for `SevenMod8`
    |
-  ::: $WORKSPACE/src/private/checks.rs
+   = help: the trait `TotalSizeIsMultipleOfEightBits` is implemented for `ZeroMod8`
+note: required by a bound in `CheckTotalSizeMultipleOf8`
+  --> src/private/checks.rs
    |
    |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsMultipleOfEightBits,
-   |                                                ------------------------------ required by this bound in `modular_bitfield::private::checks::CheckTotalSizeMultipleOf8`
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeMultipleOf8`

--- a/tests/11-bits-attribute-wrong.stderr
+++ b/tests/11-bits-attribute-wrong.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/11-bits-attribute-wrong.rs:11:7
+  --> tests/11-bits-attribute-wrong.rs:11:7
    |
 11 |     #[bits = 9]
-   |       ^^^^ expected an array with a fixed size of 9 elements, found one with 1 element
+   |       ^^^^^^^^ expected an array with a fixed size of 9 elements, found one with 1 element

--- a/tests/20-access-test.stderr
+++ b/tests/20-access-test.stderr
@@ -1,5 +1,8 @@
 error[E0624]: associated function `a` is private
-  --> $DIR/20-access-test.rs:14:15
+  --> tests/20-access-test.rs:14:15
    |
+6  |         a: B5,
+   |         ----- private associated function defined here
+...
 14 |     let _ = c.a();
    |               ^ private associated function

--- a/tests/26-invalid-struct-specifier.stderr
+++ b/tests/26-invalid-struct-specifier.stderr
@@ -1,5 +1,9 @@
 error: structs are not supported as bitfield specifiers
- --> $DIR/26-invalid-struct-specifier.rs:4:1
+ --> tests/26-invalid-struct-specifier.rs:4:1
   |
-4 | pub struct InvalidStructSpecifier {
-  | ^^^
+4 | / pub struct InvalidStructSpecifier {
+5 | |     a: bool,
+6 | |     b: B7,
+7 | |     c: u8,
+8 | | }
+  | |_^

--- a/tests/27-invalid-union-specifier.stderr
+++ b/tests/27-invalid-union-specifier.stderr
@@ -1,5 +1,9 @@
 error: unions are not supported as bitfield specifiers
- --> $DIR/27-invalid-union-specifier.rs:4:1
+ --> tests/27-invalid-union-specifier.rs:4:1
   |
-4 | pub union InvalidUnionSpecifier {
-  | ^^^
+4 | / pub union InvalidUnionSpecifier {
+5 | |     a: bool,
+6 | |     b: B7,
+7 | |     c: u8,
+8 | | }
+  | |_^

--- a/tests/bits-param/conflicting-params.stderr
+++ b/tests/bits-param/conflicting-params.stderr
@@ -1,19 +1,19 @@
 error: encountered conflicting `bits = 16` and `bytes = 4` parameters
- --> $DIR/conflicting-params.rs:3:1
+ --> tests/bits-param/conflicting-params.rs:3:1
   |
 3 | #[bitfield(bits = 16, bytes = 4)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the attribute macro `bitfield` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: conflicting `bits = 16` here
- --> $DIR/conflicting-params.rs:3:12
+ --> tests/bits-param/conflicting-params.rs:3:12
   |
 3 | #[bitfield(bits = 16, bytes = 4)]
-  |            ^^^^
+  |            ^^^^^^^^^
 
 error: conflicting `bytes = 4` here
- --> $DIR/conflicting-params.rs:3:23
+ --> tests/bits-param/conflicting-params.rs:3:23
   |
 3 | #[bitfield(bits = 16, bytes = 4)]
-  |                       ^^^^^
+  |                       ^^^^^^^^^

--- a/tests/bits-param/conflicting-repr.stderr
+++ b/tests/bits-param/conflicting-repr.stderr
@@ -1,19 +1,19 @@
 error: encountered conflicting `bits = 16` and #[repr(u32)] parameters
- --> $DIR/conflicting-repr.rs:3:1
+ --> tests/bits-param/conflicting-repr.rs:3:1
   |
 3 | #[bitfield(bits = 16)]
   | ^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the attribute macro `bitfield` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: conflicting `bits = 16` here
- --> $DIR/conflicting-repr.rs:3:12
+ --> tests/bits-param/conflicting-repr.rs:3:12
   |
 3 | #[bitfield(bits = 16)]
-  |            ^^^^
+  |            ^^^^^^^^^
 
 error: conflicting #[repr(u32)] here
- --> $DIR/conflicting-repr.rs:4:8
+ --> tests/bits-param/conflicting-repr.rs:4:8
   |
 4 | #[repr(u32)]
   |        ^^^

--- a/tests/bits-param/duplicate-param-1.stderr
+++ b/tests/bits-param/duplicate-param-1.stderr
@@ -1,11 +1,11 @@
 error: encountered duplicate `bits` parameter: duplicate set to 32
- --> $DIR/duplicate-param-1.rs:3:23
+ --> tests/bits-param/duplicate-param-1.rs:3:23
   |
 3 | #[bitfield(bits = 32, bits = 32)]
-  |                       ^^^^
+  |                       ^^^^^^^^^
 
 error: previous `bits` parameter here
- --> $DIR/duplicate-param-1.rs:3:12
+ --> tests/bits-param/duplicate-param-1.rs:3:12
   |
 3 | #[bitfield(bits = 32, bits = 32)]
-  |            ^^^^
+  |            ^^^^^^^^^

--- a/tests/bits-param/duplicate-param-2.stderr
+++ b/tests/bits-param/duplicate-param-2.stderr
@@ -1,11 +1,11 @@
 error: encountered duplicate `bits` parameter: duplicate set to 32
- --> $DIR/duplicate-param-2.rs:3:23
+ --> tests/bits-param/duplicate-param-2.rs:3:23
   |
 3 | #[bitfield(bits = 32, bits = 16)]
-  |                       ^^^^
+  |                       ^^^^^^^^^
 
 error: previous `bits` parameter here
- --> $DIR/duplicate-param-2.rs:3:12
+ --> tests/bits-param/duplicate-param-2.rs:3:12
   |
 3 | #[bitfield(bits = 32, bits = 16)]
-  |            ^^^^
+  |            ^^^^^^^^^

--- a/tests/bits-param/invalid-param-value-2.stderr
+++ b/tests/bits-param/invalid-param-value-2.stderr
@@ -1,5 +1,5 @@
 error: encountered malformatted integer value for `bits` parameter: invalid digit found in string
- --> $DIR/invalid-param-value-2.rs:3:19
+ --> tests/bits-param/invalid-param-value-2.rs:3:19
   |
 3 | #[bitfield(bits = -1)]
-  |                   ^
+  |                   ^^

--- a/tests/bits-param/too-few-bits.stderr
+++ b/tests/bits-param/too-few-bits.stderr
@@ -1,10 +1,15 @@
-error[E0277]: the trait bound `modular_bitfield::private::checks::False: modular_bitfield::private::checks::FillsUnalignedBits` is not satisfied
-   --> $DIR/too-few-bits.rs:4:1
-    |
-4   | pub struct SignInteger {
-    | ^^^ the trait `modular_bitfield::private::checks::FillsUnalignedBits` is not implemented for `modular_bitfield::private::checks::False`
-    |
-   ::: $WORKSPACE/src/private/checks.rs
-    |
-    |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
-    |                                                  ------------------ required by this bound in `modular_bitfield::private::checks::CheckFillsUnalignedBits`
+error[E0277]: the trait bound `False: FillsUnalignedBits` is not satisfied
+ --> tests/bits-param/too-few-bits.rs:4:1
+  |
+4 | / pub struct SignInteger {
+5 | |     sign: bool,
+6 | |     value: B31,
+7 | | }
+  | |_^ the trait `FillsUnalignedBits` is not implemented for `False`
+  |
+  = help: the trait `FillsUnalignedBits` is implemented for `True`
+note: required by a bound in `CheckFillsUnalignedBits`
+ --> src/private/checks.rs
+  |
+  |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
+  |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits`

--- a/tests/bits-param/too-many-bits.stderr
+++ b/tests/bits-param/too-many-bits.stderr
@@ -1,10 +1,15 @@
-error[E0277]: the trait bound `modular_bitfield::private::checks::False: modular_bitfield::private::checks::FillsUnalignedBits` is not satisfied
-   --> $DIR/too-many-bits.rs:4:1
-    |
-4   | pub struct SignInteger {
-    | ^^^ the trait `modular_bitfield::private::checks::FillsUnalignedBits` is not implemented for `modular_bitfield::private::checks::False`
-    |
-   ::: $WORKSPACE/src/private/checks.rs
-    |
-    |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
-    |                                                  ------------------ required by this bound in `modular_bitfield::private::checks::CheckFillsUnalignedBits`
+error[E0277]: the trait bound `False: FillsUnalignedBits` is not satisfied
+ --> tests/bits-param/too-many-bits.rs:4:1
+  |
+4 | / pub struct SignInteger {
+5 | |     sign: bool,
+6 | |     value: B31,
+7 | | }
+  | |_^ the trait `FillsUnalignedBits` is not implemented for `False`
+  |
+  = help: the trait `FillsUnalignedBits` is implemented for `True`
+note: required by a bound in `CheckFillsUnalignedBits`
+ --> src/private/checks.rs
+  |
+  |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
+  |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits`

--- a/tests/bytes-param/duplicate-parameters.stderr
+++ b/tests/bytes-param/duplicate-parameters.stderr
@@ -1,11 +1,11 @@
 error: encountered duplicate `bytes` parameter: duplicate set to 4
- --> $DIR/duplicate-parameters.rs:4:23
+ --> tests/bytes-param/duplicate-parameters.rs:4:23
   |
 4 | #[bitfield(bytes = 4, bytes = 4)]
-  |                       ^^^^^
+  |                       ^^^^^^^^^
 
 error: previous `bytes` parameter here
- --> $DIR/duplicate-parameters.rs:4:12
+ --> tests/bytes-param/duplicate-parameters.rs:4:12
   |
 4 | #[bitfield(bytes = 4, bytes = 4)]
-  |            ^^^^^
+  |            ^^^^^^^^^

--- a/tests/bytes-param/fewer-bytes-than-expected.stderr
+++ b/tests/bytes-param/fewer-bytes-than-expected.stderr
@@ -1,9 +1,17 @@
-error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
- --> $DIR/fewer-bytes-than-expected.rs:4:12
+warning: unnecessary trailing semicolon
+ --> tests/bytes-param/fewer-bytes-than-expected.rs:4:12
   |
 4 | #[bitfield(bytes = 4)]
-  |            ^^^^^
+  |            ^^^^^^^^^ help: remove this semicolon
   |
-  = note: source type: `_::ExpectedBytes` (32 bits)
+  = note: `#[warn(redundant_semicolons)]` on by default
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+ --> tests/bytes-param/fewer-bytes-than-expected.rs:4:12
+  |
+4 | #[bitfield(bytes = 4)]
+  |            ^^^^^^^^^
+  |
+  = note: source type: `ExpectedBytes` (32 bits)
   = note: target type: `Base` (24 bits)
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `::modular_bitfield::private::static_assertions::assert_eq_size` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/bytes-param/invalid-int-value.stderr
+++ b/tests/bytes-param/invalid-int-value.stderr
@@ -1,5 +1,5 @@
 error: encountered malformatted integer value for `bytes` parameter: invalid digit found in string
- --> $DIR/invalid-int-value.rs:4:20
+ --> tests/bytes-param/invalid-int-value.rs:4:20
   |
 4 | #[bitfield(bytes = -1)]
-  |                    ^
+  |                    ^^

--- a/tests/bytes-param/more-bytes-than-expected.stderr
+++ b/tests/bytes-param/more-bytes-than-expected.stderr
@@ -1,9 +1,17 @@
-error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
- --> $DIR/more-bytes-than-expected.rs:4:12
+warning: unnecessary trailing semicolon
+ --> tests/bytes-param/more-bytes-than-expected.rs:4:12
   |
 4 | #[bitfield(bytes = 4)]
-  |            ^^^^^
+  |            ^^^^^^^^^ help: remove this semicolon
   |
-  = note: source type: `_::ExpectedBytes` (32 bits)
+  = note: `#[warn(redundant_semicolons)]` on by default
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+ --> tests/bytes-param/more-bytes-than-expected.rs:4:12
+  |
+4 | #[bitfield(bytes = 4)]
+  |            ^^^^^^^^^
+  |
+  = note: source type: `ExpectedBytes` (32 bits)
   = note: target type: `Base` (48 bits)
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `::modular_bitfield::private::static_assertions::assert_eq_size` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/derive-bitfield-specifier/08-non-power-of-two.stderr
+++ b/tests/derive-bitfield-specifier/08-non-power-of-two.stderr
@@ -1,5 +1,9 @@
 error: BitfieldSpecifier expected a number of variants which is a power of 2, specify #[bits = 2] if that was your intent
-  --> $DIR/08-non-power-of-two.rs:11:1
+  --> tests/derive-bitfield-specifier/08-non-power-of-two.rs:11:1
    |
-11 | pub enum Bad {
-   | ^^^
+11 | / pub enum Bad {
+12 | |     Zero,
+13 | |     One,
+14 | |     Two,
+15 | | }
+   | |_^

--- a/tests/derive-bitfield-specifier/09-variant-out-of-range.stderr
+++ b/tests/derive-bitfield-specifier/09-variant-out-of-range.stderr
@@ -1,10 +1,12 @@
-error[E0277]: the trait bound `modular_bitfield::private::checks::False: modular_bitfield::private::checks::DiscriminantInRange` is not satisfied
-   --> $DIR/09-variant-out-of-range.rs:17:5
-    |
-17  |     External,
-    |     ^^^^^^^^ the trait `modular_bitfield::private::checks::DiscriminantInRange` is not implemented for `modular_bitfield::private::checks::False`
-    |
-   ::: $WORKSPACE/src/private/checks.rs
-    |
-    |     <Self::CheckType as DispatchTrueFalse>::Out: DiscriminantInRange,
-    |                                                  ------------------- required by this bound in `modular_bitfield::private::checks::CheckDiscriminantInRange`
+error[E0277]: the trait bound `False: DiscriminantInRange` is not satisfied
+  --> tests/derive-bitfield-specifier/09-variant-out-of-range.rs:17:5
+   |
+17 |     External,
+   |     ^^^^^^^^ the trait `DiscriminantInRange` is not implemented for `False`
+   |
+   = help: the trait `DiscriminantInRange` is implemented for `True`
+note: required by a bound in `CheckDiscriminantInRange`
+  --> src/private/checks.rs
+   |
+   |     <Self::CheckType as DispatchTrueFalse>::Out: DiscriminantInRange,
+   |                                                  ^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckDiscriminantInRange`

--- a/tests/derive-specifier/out-of-bounds.stderr
+++ b/tests/derive-specifier/out-of-bounds.stderr
@@ -1,10 +1,16 @@
-error[E0277]: the trait bound `modular_bitfield::private::checks::False: modular_bitfield::private::checks::SpecifierHasAtMost128Bits` is not satisfied
-   --> $DIR/out-of-bounds.rs:4:1
-    |
-4   | #[derive(BitfieldSpecifier, Debug)]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `modular_bitfield::private::checks::SpecifierHasAtMost128Bits` is not implemented for `modular_bitfield::private::checks::False`
-    |
-   ::: $WORKSPACE/src/private/checks.rs
-    |
-    |     <Self::CheckType as DispatchTrueFalse>::Out: SpecifierHasAtMost128Bits,
-    |                                                  ------------------------- required by this bound in `modular_bitfield::private::checks::CheckSpecifierHasAtMost128Bits`
+error[E0277]: the trait bound `False: SpecifierHasAtMost128Bits` is not satisfied
+ --> tests/derive-specifier/out-of-bounds.rs:4:1
+  |
+4 | / #[derive(BitfieldSpecifier, Debug)]
+5 | | pub struct Header {
+6 | |     a: B1,
+7 | |     b: B128,
+8 | | }
+  | |_^ the trait `SpecifierHasAtMost128Bits` is not implemented for `False`
+  |
+  = help: the trait `SpecifierHasAtMost128Bits` is implemented for `True`
+note: required by a bound in `CheckSpecifierHasAtMost128Bits`
+ --> src/private/checks.rs
+  |
+  |     <Self::CheckType as DispatchTrueFalse>::Out: SpecifierHasAtMost128Bits,
+  |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckSpecifierHasAtMost128Bits`

--- a/tests/filled-param/duplicate-parameters.stderr
+++ b/tests/filled-param/duplicate-parameters.stderr
@@ -1,11 +1,11 @@
 error: encountered duplicate `filled` parameter: duplicate set to true
- --> $DIR/duplicate-parameters.rs:4:27
+ --> tests/filled-param/duplicate-parameters.rs:4:27
   |
 4 | #[bitfield(filled = true, filled = true)]
-  |                           ^^^^^^
+  |                           ^^^^^^^^^^^^^
 
 error: previous `filled` parameter here
- --> $DIR/duplicate-parameters.rs:4:12
+ --> tests/filled-param/duplicate-parameters.rs:4:12
   |
 4 | #[bitfield(filled = true, filled = true)]
-  |            ^^^^^^
+  |            ^^^^^^^^^^^^^

--- a/tests/filled-param/invalid-specified-as-filled.stderr
+++ b/tests/filled-param/invalid-specified-as-filled.stderr
@@ -1,10 +1,15 @@
-error[E0277]: the trait bound `modular_bitfield::private::checks::SevenMod8: modular_bitfield::private::checks::TotalSizeIsMultipleOfEightBits` is not satisfied
-  --> $DIR/invalid-specified-as-filled.rs:5:1
-   |
-5  | pub struct UnfilledBitfield {
-   | ^^^ the trait `modular_bitfield::private::checks::TotalSizeIsMultipleOfEightBits` is not implemented for `modular_bitfield::private::checks::SevenMod8`
-   |
-  ::: $WORKSPACE/src/private/checks.rs
-   |
-   |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsMultipleOfEightBits,
-   |                                                ------------------------------ required by this bound in `modular_bitfield::private::checks::CheckTotalSizeMultipleOf8`
+error[E0277]: the trait bound `SevenMod8: TotalSizeIsMultipleOfEightBits` is not satisfied
+ --> tests/filled-param/invalid-specified-as-filled.rs:5:1
+  |
+5 | / pub struct UnfilledBitfield {
+6 | |     a: B7,
+7 | |     b: u8,
+8 | | }
+  | |_^ the trait `TotalSizeIsMultipleOfEightBits` is not implemented for `SevenMod8`
+  |
+  = help: the trait `TotalSizeIsMultipleOfEightBits` is implemented for `ZeroMod8`
+note: required by a bound in `CheckTotalSizeMultipleOf8`
+ --> src/private/checks.rs
+  |
+  |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsMultipleOfEightBits,
+  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeMultipleOf8`

--- a/tests/filled-param/invalid-specified-as-unfilled.stderr
+++ b/tests/filled-param/invalid-specified-as-unfilled.stderr
@@ -1,10 +1,22 @@
-error[E0277]: the trait bound `modular_bitfield::private::checks::ZeroMod8: modular_bitfield::private::checks::TotalSizeIsNotMultipleOfEightBits` is not satisfied
-  --> $DIR/invalid-specified-as-unfilled.rs:5:1
-   |
-5  | pub struct UnfilledBitfield {
-   | ^^^ the trait `modular_bitfield::private::checks::TotalSizeIsNotMultipleOfEightBits` is not implemented for `modular_bitfield::private::checks::ZeroMod8`
-   |
-  ::: $WORKSPACE/src/private/checks.rs
-   |
-   |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsNotMultipleOfEightBits,
-   |                                                --------------------------------- required by this bound in `modular_bitfield::private::checks::CheckTotalSizeIsNotMultipleOf8`
+error[E0277]: the trait bound `ZeroMod8: TotalSizeIsNotMultipleOfEightBits` is not satisfied
+ --> tests/filled-param/invalid-specified-as-unfilled.rs:5:1
+  |
+5 | / pub struct UnfilledBitfield {
+6 | |     a: B8,
+7 | |     b: u8,
+8 | | }
+  | |_^ the trait `TotalSizeIsNotMultipleOfEightBits` is not implemented for `ZeroMod8`
+  |
+  = help: the following other types implement trait `TotalSizeIsNotMultipleOfEightBits`:
+            FiveMod8
+            FourMod8
+            OneMod8
+            SevenMod8
+            SixMod8
+            ThreeMod8
+            TwoMod8
+note: required by a bound in `CheckTotalSizeIsNotMultipleOf8`
+ --> src/private/checks.rs
+  |
+  |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsNotMultipleOfEightBits,
+  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeIsNotMultipleOf8`

--- a/tests/repr/invalid-repr-1.stderr
+++ b/tests/repr/invalid-repr-1.stderr
@@ -1,5 +1,7 @@
 error[E0552]: unrecognized representation hint
- --> $DIR/invalid-repr-1.rs:4:8
+ --> tests/repr/invalid-repr-1.rs:4:8
   |
 4 | #[repr(invalid)]
   |        ^^^^^^^
+  |
+  = help: valid reprs are `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`

--- a/tests/repr/invalid-repr-2.stderr
+++ b/tests/repr/invalid-repr-2.stderr
@@ -1,5 +1,7 @@
 error[E0552]: unrecognized representation hint
- --> $DIR/invalid-repr-2.rs:4:43
+ --> tests/repr/invalid-repr-2.rs:4:43
   |
 4 | #[cfg_attr(not(feature = "unknown"), repr(invalid))]
   |                                           ^^^^^^^
+  |
+  = help: valid reprs are `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`

--- a/tests/repr/invalid-repr-unfilled.stderr
+++ b/tests/repr/invalid-repr-unfilled.stderr
@@ -1,19 +1,19 @@
 error: encountered conflicting `#[repr(u32)]` and `filled = false` parameters
- --> $DIR/invalid-repr-unfilled.rs:3:1
+ --> tests/repr/invalid-repr-unfilled.rs:3:1
   |
 3 | #[bitfield(filled = false)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the attribute macro `bitfield` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: conflicting `#[repr(u32)]` here
- --> $DIR/invalid-repr-unfilled.rs:4:8
+ --> tests/repr/invalid-repr-unfilled.rs:4:8
   |
 4 | #[repr(u32)]
   |        ^^^
 
 error: conflicting `filled = false` here
- --> $DIR/invalid-repr-unfilled.rs:3:12
+ --> tests/repr/invalid-repr-unfilled.rs:3:12
   |
 3 | #[bitfield(filled = false)]
-  |            ^^^^^^
+  |            ^^^^^^^^^^^^^^

--- a/tests/repr/invalid-repr-width-1.stderr
+++ b/tests/repr/invalid-repr-width-1.stderr
@@ -1,9 +1,10 @@
-error[E0277]: the trait bound `[(); 32]: modular_bitfield::private::IsU16Compatible` is not satisfied
- --> $DIR/invalid-repr-width-1.rs:4:8
+error[E0277]: the trait bound `[(); 32]: IsU16Compatible` is not satisfied
+ --> tests/repr/invalid-repr-width-1.rs:3:1
   |
-4 | #[repr(u16)] // Too few bits!
-  |        ^^^ the trait `modular_bitfield::private::IsU16Compatible` is not implemented for `[(); 32]`
+3 | #[bitfield]
+  | ^^^^^^^^^^^ the trait `IsU16Compatible` is not implemented for `[(); 32]`
   |
-  = help: the following implementations were found:
-            <[(); 16] as modular_bitfield::private::IsU16Compatible>
+  = help: the trait `IsU16Compatible` is implemented for `[(); 16]`
   = help: see issue #48214
+  = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+  = note: this error originates in the attribute macro `bitfield` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/repr/invalid-repr-width-2.stderr
+++ b/tests/repr/invalid-repr-width-2.stderr
@@ -1,9 +1,10 @@
-error[E0277]: the trait bound `[(); 32]: modular_bitfield::private::IsU64Compatible` is not satisfied
- --> $DIR/invalid-repr-width-2.rs:4:8
+error[E0277]: the trait bound `[(); 32]: IsU64Compatible` is not satisfied
+ --> tests/repr/invalid-repr-width-2.rs:3:1
   |
-4 | #[repr(u64)] // Too many bits!
-  |        ^^^ the trait `modular_bitfield::private::IsU64Compatible` is not implemented for `[(); 32]`
+3 | #[bitfield]
+  | ^^^^^^^^^^^ the trait `IsU64Compatible` is not implemented for `[(); 32]`
   |
-  = help: the following implementations were found:
-            <[(); 64] as modular_bitfield::private::IsU64Compatible>
+  = help: the trait `IsU64Compatible` is implemented for `[(); 64]`
   = help: see issue #48214
+  = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+  = note: this error originates in the attribute macro `bitfield` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/skip/duplicate-getters-1.stderr
+++ b/tests/skip/duplicate-getters-1.stderr
@@ -1,11 +1,11 @@
 error: encountered duplicate `#[skip(getters)]` attribute for field
- --> $DIR/duplicate-getters-1.rs:5:24
+ --> tests/skip/duplicate-getters-1.rs:5:24
   |
 5 |     #[skip(getters)] #[skip(getters)]
-  |                        ^^^^
+  |                        ^^^^^^^^^^^^^
 
 error: duplicate `#[skip(getters)]` here
- --> $DIR/duplicate-getters-1.rs:5:7
+ --> tests/skip/duplicate-getters-1.rs:5:7
   |
 5 |     #[skip(getters)] #[skip(getters)]
-  |       ^^^^
+  |       ^^^^^^^^^^^^^

--- a/tests/skip/duplicate-getters-2.stderr
+++ b/tests/skip/duplicate-getters-2.stderr
@@ -1,11 +1,11 @@
 error: encountered duplicate `#[skip(getters)]` attribute for field
- --> $DIR/duplicate-getters-2.rs:5:15
+ --> tests/skip/duplicate-getters-2.rs:5:15
   |
 5 |     #[skip] #[skip(getters)]
-  |               ^^^^
+  |               ^^^^^^^^^^^^^
 
 error: duplicate `#[skip(getters)]` here
- --> $DIR/duplicate-getters-2.rs:5:7
+ --> tests/skip/duplicate-getters-2.rs:5:7
   |
 5 |     #[skip] #[skip(getters)]
   |       ^^^^

--- a/tests/skip/duplicate-getters-3.stderr
+++ b/tests/skip/duplicate-getters-3.stderr
@@ -1,11 +1,11 @@
 error: encountered duplicate `#[skip]` attribute for field
- --> $DIR/duplicate-getters-3.rs:5:24
+ --> tests/skip/duplicate-getters-3.rs:5:24
   |
 5 |     #[skip(getters)] #[skip]
   |                        ^^^^
 
 error: duplicate `#[skip]` here
- --> $DIR/duplicate-getters-3.rs:5:7
+ --> tests/skip/duplicate-getters-3.rs:5:7
   |
 5 |     #[skip(getters)] #[skip]
-  |       ^^^^
+  |       ^^^^^^^^^^^^^

--- a/tests/skip/duplicate-setters-1.stderr
+++ b/tests/skip/duplicate-setters-1.stderr
@@ -1,11 +1,11 @@
 error: encountered duplicate `#[skip(setters)]` attribute for field
- --> $DIR/duplicate-setters-1.rs:5:24
+ --> tests/skip/duplicate-setters-1.rs:5:24
   |
 5 |     #[skip(setters)] #[skip(setters)]
-  |                        ^^^^
+  |                        ^^^^^^^^^^^^^
 
 error: duplicate `#[skip(setters)]` here
- --> $DIR/duplicate-setters-1.rs:5:7
+ --> tests/skip/duplicate-setters-1.rs:5:7
   |
 5 |     #[skip(setters)] #[skip(setters)]
-  |       ^^^^
+  |       ^^^^^^^^^^^^^

--- a/tests/skip/duplicate-setters-2.stderr
+++ b/tests/skip/duplicate-setters-2.stderr
@@ -1,11 +1,11 @@
 error: encountered duplicate `#[skip(setters)]` attribute for field
- --> $DIR/duplicate-setters-2.rs:5:15
+ --> tests/skip/duplicate-setters-2.rs:5:15
   |
 5 |     #[skip] #[skip(setters)]
-  |               ^^^^
+  |               ^^^^^^^^^^^^^
 
 error: duplicate `#[skip(setters)]` here
- --> $DIR/duplicate-setters-2.rs:5:7
+ --> tests/skip/duplicate-setters-2.rs:5:7
   |
 5 |     #[skip] #[skip(setters)]
   |       ^^^^

--- a/tests/skip/duplicate-setters-3.stderr
+++ b/tests/skip/duplicate-setters-3.stderr
@@ -1,11 +1,11 @@
 error: encountered duplicate `#[skip]` attribute for field
- --> $DIR/duplicate-setters-3.rs:5:24
+ --> tests/skip/duplicate-setters-3.rs:5:24
   |
 5 |     #[skip(setters)] #[skip]
   |                        ^^^^
 
 error: duplicate `#[skip]` here
- --> $DIR/duplicate-setters-3.rs:5:7
+ --> tests/skip/duplicate-setters-3.rs:5:7
   |
 5 |     #[skip(setters)] #[skip]
-  |       ^^^^
+  |       ^^^^^^^^^^^^^

--- a/tests/skip/duplicate-specifier.stderr
+++ b/tests/skip/duplicate-specifier.stderr
@@ -1,11 +1,11 @@
 error: encountered duplicate #[skip(getters)]
- --> $DIR/duplicate-specifier.rs:5:7
+ --> tests/skip/duplicate-specifier.rs:5:7
   |
 5 |     #[skip(getters, getters)]
-  |       ^^^^
+  |       ^^^^^^^^^^^^^^^^^^^^^^
 
 error: previous found here
- --> $DIR/duplicate-specifier.rs:5:7
+ --> tests/skip/duplicate-specifier.rs:5:7
   |
 5 |     #[skip(getters, getters)]
-  |       ^^^^
+  |       ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/skip/use-skipped-getter-1.stderr
+++ b/tests/skip/use-skipped-getter-1.stderr
@@ -1,9 +1,9 @@
 error[E0599]: no method named `unused_1` found for struct `Sparse` in the current scope
-  --> $DIR/use-skipped-getter-1.rs:14:23
+  --> tests/skip/use-skipped-getter-1.rs:14:23
    |
 4  | / #[derive(Debug)]
 5  | | pub struct Sparse {
-   | |___- method `unused_1` not found for this
+   | |_________________- method `unused_1` not found for this struct
 ...
 14 |       assert_eq!(sparse.unused_1(), 0); // ERROR!
-   |                         ^^^^^^^^ method not found in `Sparse`
+   |                         ^^^^^^^^ help: there is a method with a similar name: `set_unused_1`

--- a/tests/skip/use-skipped-getter-2.stderr
+++ b/tests/skip/use-skipped-getter-2.stderr
@@ -1,9 +1,9 @@
 error[E0599]: no method named `unused_1` found for struct `Sparse` in the current scope
-  --> $DIR/use-skipped-getter-2.rs:13:23
+  --> tests/skip/use-skipped-getter-2.rs:13:23
    |
 4  | / #[derive(Debug)]
 5  | | pub struct Sparse {
-   | |___- method `unused_1` not found for this
+   | |_________________- method `unused_1` not found for this struct
 ...
 13 |       assert_eq!(sparse.unused_1(), 0xFE); // ERROR!
    |                         ^^^^^^^^ method not found in `Sparse`

--- a/tests/skip/use-skipped-getter-3.stderr
+++ b/tests/skip/use-skipped-getter-3.stderr
@@ -1,9 +1,9 @@
 error[E0599]: no method named `unused_1` found for struct `Sparse` in the current scope
-  --> $DIR/use-skipped-getter-3.rs:13:23
+  --> tests/skip/use-skipped-getter-3.rs:13:23
    |
 4  | / #[derive(Debug)]
 5  | | pub struct Sparse {
-   | |___- method `unused_1` not found for this
+   | |_________________- method `unused_1` not found for this struct
 ...
 13 |       assert_eq!(sparse.unused_1(), 0xFE); // ERROR!
    |                         ^^^^^^^^ method not found in `Sparse`

--- a/tests/skip/use-skipped-setter-1.stderr
+++ b/tests/skip/use-skipped-setter-1.stderr
@@ -1,9 +1,9 @@
 error[E0599]: no method named `set_unused_1` found for struct `Sparse` in the current scope
-  --> $DIR/use-skipped-setter-1.rs:14:12
+  --> tests/skip/use-skipped-setter-1.rs:14:12
    |
 4  | / #[derive(Debug)]
 5  | | pub struct Sparse {
-   | |___- method `set_unused_1` not found for this
+   | |_________________- method `set_unused_1` not found for this struct
 ...
 14 |       sparse.set_unused_1(0b11_1111_1111); // ERROR!
-   |              ^^^^^^^^^^^^ help: there is an associated function with a similar name: `unused_1`
+   |              ^^^^^^^^^^^^ help: there is a method with a similar name: `unused_1`

--- a/tests/skip/use-skipped-setter-2.stderr
+++ b/tests/skip/use-skipped-setter-2.stderr
@@ -1,9 +1,9 @@
 error[E0599]: no method named `set_unused_1` found for struct `Sparse` in the current scope
-  --> $DIR/use-skipped-setter-2.rs:13:12
+  --> tests/skip/use-skipped-setter-2.rs:13:12
    |
 4  | / #[derive(Debug)]
 5  | | pub struct Sparse {
-   | |___- method `set_unused_1` not found for this
+   | |_________________- method `set_unused_1` not found for this struct
 ...
 13 |       sparse.set_unused_1(0); // ERROR!
    |              ^^^^^^^^^^^^ method not found in `Sparse`

--- a/tests/skip/use-skipped-setter-3.stderr
+++ b/tests/skip/use-skipped-setter-3.stderr
@@ -1,9 +1,9 @@
 error[E0599]: no method named `set_unused_1` found for struct `Sparse` in the current scope
-  --> $DIR/use-skipped-setter-3.rs:13:12
+  --> tests/skip/use-skipped-setter-3.rs:13:12
    |
 4  | / #[derive(Debug)]
 5  | | pub struct Sparse {
-   | |___- method `set_unused_1` not found for this
+   | |_________________- method `set_unused_1` not found for this struct
 ...
 13 |       sparse.set_unused_1(0); // ERROR!
    |              ^^^^^^^^^^^^ method not found in `Sparse`


### PR DESCRIPTION
This fixes #65 in the simplest way possible. It's not ideal, but it's way better than spamming the consumer with compiler warnings.

The first commit makes the tests pass **before** my change. Seems the compiler errors have changed since those tests were last updated. Note that I haven't checked the test blessing thoroughly. This does also raise the question of if this crate is maintained. Is it maintained?