### PR TITLE
[impl] remove extra semicolon in bytes check

### DIFF
--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -344,7 +344,7 @@ impl BitfieldStruct {
             let bytes = config.value;
             quote_spanned!(config.span=>
                 const _: () = {
-                    struct ExpectedBytes { __bf_unused: [::core::primitive::u8; #bytes] };
+                    struct ExpectedBytes { __bf_unused: [::core::primitive::u8; #bytes] }
 
                     ::modular_bitfield::private::static_assertions::assert_eq_size!(
                         ExpectedBytes,


### PR DESCRIPTION
While using the bytes check I've received a lint about an extra semicolon. I've glanced over the source and found it!