### PR TITLE
use SPDX license format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "modular-bitfield"
 version = "0.11.2"
 edition = "2018"
 authors = ["Robin Freyler <robinfreyler@web.de>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 repository = "https://github.com/robbepop/modular-bitfield"

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -3,7 +3,7 @@ name = "modular-bitfield-impl"
 version = "0.11.2"
 edition = "2018"
 authors = ["Robin Freyler <robinfreyler@web.de>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "../README.md"
 
 repository = "https://github.com/robbepop/modular-bitfield"


### PR DESCRIPTION
The use of `/` as a separator in the license field is deprecated.

https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields