### PR TITLE
Default field attribute and derive default support

### DIFF
--- a/impl/src/bitfield/analyse.rs
+++ b/impl/src/bitfield/analyse.rs
@@ -110,6 +110,8 @@ impl BitfieldStruct {
             let path = &meta.path;
             if path.is_ident("Debug") {
                 config.derive_debug(path.span())?;
+            } else if path.is_ident("Default") {
+                config.derive_default(path.span())?;
             } else if path.is_ident("Specifier") {
                 config.derive_specifier(path.span())?;
             } else {
@@ -165,7 +167,7 @@ impl BitfieldStruct {
 
     /// Extracts the `#[bits = N]` and `#[skip(..)]` attributes for a given field.
     fn extract_field_config(field: &syn::Field) -> Result<FieldConfig> {
-        let mut config = FieldConfig::default();
+        let mut config = FieldConfig::new();
         for attr in &field.attrs {
             if attr.path().is_ident("bits") {
                 let name_value = attr.meta.require_name_value()?;
@@ -223,6 +225,19 @@ impl BitfieldStruct {
                         return Err(format_err!(
                             meta.span(),
                             "encountered invalid format for #[skip] field attribute"
+                        ))
+                    }
+                }
+            } else if attr.path().is_ident("default") {
+                match &attr.meta {
+                    syn::Meta::NameValue(name_value) => {
+                        let default_value = name_value.value.clone();
+                        config.default(default_value, name_value.span())?;
+                    }
+                    meta => {
+                        return Err(format_err!(
+                            meta.span(),
+                            "encountered invalid format for #[default] field attribute, expected #[default = expression]"
                         ))
                     }
                 }

--- a/impl/src/bitfield/config.rs
+++ b/impl/src/bitfield/config.rs
@@ -13,6 +13,7 @@ pub struct Config {
     pub filled: Option<ConfigValue<bool>>,
     pub repr: Option<ConfigValue<ReprKind>>,
     pub derive_debug: Option<ConfigValue<()>>,
+    pub derive_default: Option<ConfigValue<()>>,
     pub derive_specifier: Option<ConfigValue<()>>,
     pub retained_attributes: Vec<syn::Attribute>,
     pub field_configs: HashMap<usize, ConfigValue<FieldConfig>>,
@@ -227,23 +228,32 @@ impl Config {
         Ok(())
     }
 
+    /// Helper function to register derive attributes.
+    fn derive_attr(name: &str, field: &mut Option<ConfigValue<()>>, span: Span) -> Result<()> {
+        if let Some(previous) = field {
+            Err(Self::raise_duplicate_error(name, span, previous))
+        } else {
+            *field = Some(ConfigValue::new((), span));
+            Ok(())
+        }
+    }
+
     /// Registers the `#[derive(Debug)]` attribute for the #[bitfield] macro.
     ///
     /// # Errors
     ///
     /// If a `#[derive(Debug)]` attribute has already been found.
     pub fn derive_debug(&mut self, span: Span) -> Result<()> {
-        match &self.derive_debug {
-            Some(previous) => {
-                return Err(Self::raise_duplicate_error(
-                    "#[derive(Debug)]",
-                    span,
-                    previous,
-                ))
-            }
-            None => self.derive_debug = Some(ConfigValue::new((), span)),
-        }
-        Ok(())
+        Self::derive_attr("#[derive(Debug)]", &mut self.derive_debug, span)
+    }
+
+    /// Registers the `#[derive(Default)]` attribute for the #[bitfield] macro.
+    ///
+    /// # Errors
+    ///
+    /// If a `#[derive(Default)]` attribute has already been found.
+    pub fn derive_default(&mut self, span: Span) -> Result<()> {
+        Self::derive_attr("#[derive(Default)]", &mut self.derive_default, span)
     }
 
     /// Registers the `#[derive(Specifier)]` attribute for the #[bitfield] macro.
@@ -252,17 +262,7 @@ impl Config {
     ///
     /// If a `#[derive(Specifier)]` attribute has already been found.
     pub fn derive_specifier(&mut self, span: Span) -> Result<()> {
-        match &self.derive_specifier {
-            Some(previous) => {
-                return Err(Self::raise_duplicate_error(
-                    "#[derive(Specifier)]",
-                    span,
-                    previous,
-                ))
-            }
-            None => self.derive_specifier = Some(ConfigValue::new((), span)),
-        }
-        Ok(())
+        Self::derive_attr("#[derive(Specifier)]", &mut self.derive_specifier, span)
     }
 
     /// Pushes another retained attribute that the #[bitfield] macro is going to re-expand and ignore.

--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -838,7 +838,8 @@ impl BitfieldStruct {
 
         for info in self.field_infos(config) {
             let field_type = &info.field.ty;
-            let field_bits = quote_spanned!(span=> <#field_type as ::modular_bitfield::Specifier>::BITS);
+            let field_bits =
+                quote_spanned!(span=> <#field_type as ::modular_bitfield::Specifier>::BITS);
 
             let field_config = &info.config;
             let const_value = if let Some(default_config) = &field_config.default {

--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -21,6 +21,7 @@ impl BitfieldStruct {
         let bytes_check = self.expand_optional_bytes_check(config);
         let repr_impls_and_checks = self.expand_repr_from_impls_and_checks(config);
         let debug_impl = self.generate_debug_impl(config);
+        let default_impl = self.generate_default_impl(config);
 
         quote_spanned!(span=>
             #struct_definition
@@ -32,6 +33,7 @@ impl BitfieldStruct {
             #bytes_check
             #repr_impls_and_checks
             #debug_impl
+            #default_impl
         )
     }
 
@@ -48,6 +50,26 @@ impl BitfieldStruct {
         let bits = self.generate_target_or_actual_bitfield_size(config);
         let next_divisible_by_8 = Self::next_divisible_by_8(&bits);
 
+        let has_defaults = self
+            .field_infos(config)
+            .any(|info| info.config.default.is_some());
+
+        let default_impl = if has_defaults {
+            let byte_count = quote_spanned!(span=> #next_divisible_by_8 / 8);
+            let default_bytes = self.generate_const_default_bytes(config, &byte_count);
+
+            quote_spanned!(span=>
+                const DEFAULT: Self::Bytes = {
+                    let bytes: [u8; #byte_count] = #default_bytes;
+                    Self::Bytes::from_le_bytes(bytes)
+                };
+            )
+        } else {
+            quote_spanned!(span=>
+                const DEFAULT: Self::Bytes = 0;
+            )
+        };
+
         Some(quote_spanned!(span=>
             const _: () = {
                 impl #impl_generics ::modular_bitfield::private::checks::CheckSpecifierHasAtMost128Bits for #ident #ty_generics #where_clause {
@@ -57,6 +79,7 @@ impl BitfieldStruct {
 
             impl #impl_generics ::modular_bitfield::Specifier for #ident #ty_generics #where_clause {
                 const BITS: ::core::primitive::usize = #bits;
+                #default_impl
 
                 type Bytes = <::modular_bitfield::private::checks::BitCount<{if #bits > 128 { 128 } else { #bits }}> as ::modular_bitfield::private::SpecifierBytes>::Bytes;
                 type InOut = Self;
@@ -113,7 +136,7 @@ impl BitfieldStruct {
                 field,
                 config,
             } = &info;
-            if config.skip_getters() {
+            if config.skip_getters().is_some() {
                 return None;
             }
             let field_span = field.span();
@@ -146,6 +169,22 @@ impl BitfieldStruct {
                     __bf_f.#builder_name(::core::stringify!(#ident))
                         #( #fields )*
                         .finish()
+                }
+            }
+        ))
+    }
+
+    /// Generates the `Default` impl for the `#[bitfield]` struct.
+    pub fn generate_default_impl(&self, config: &Config) -> Option<TokenStream2> {
+        config.derive_default.as_ref()?;
+        let span = self.item_struct.span();
+        let ident = &self.item_struct.ident;
+        let (impl_generics, ty_generics, where_clause) = self.item_struct.generics.split_for_impl();
+
+        Some(quote_spanned!(span=>
+            impl #impl_generics ::core::default::Default for #ident #ty_generics #where_clause {
+                fn default() -> Self {
+                    Self::new()
                 }
             }
         ))
@@ -309,26 +348,84 @@ impl BitfieldStruct {
         )
     }
 
-    /// Generates the constructor for the bitfield that initializes all bytes to zero.
+    /// Generates the constructor for the bitfield.
     fn generate_constructor(&self, config: &Config) -> TokenStream2 {
         let span = self.item_struct.span();
         let ident = &self.item_struct.ident;
         let (impl_generics, ty_generics, where_clause) = self.item_struct.generics.split_for_impl();
         let size = self.generate_target_or_actual_bitfield_size(config);
         let next_divisible_by_8 = Self::next_divisible_by_8(&size);
-        quote_spanned!(span=>
-            impl #impl_generics #ident #ty_generics #where_clause
-            {
-                /// Returns an instance with zero initialized data.
-                #[allow(clippy::new_without_default)]
-                #[must_use]
-                pub const fn new() -> Self {
-                    Self {
-                        bytes: [0_u8; #next_divisible_by_8 / 8],
+        let byte_count = quote_spanned!(span=> #next_divisible_by_8 / 8);
+
+        let has_defaults = self
+            .field_infos(config)
+            .any(|info| info.config.default.is_some());
+        let derives_specifier = config.derive_specifier.is_some();
+
+        match (has_defaults, derives_specifier) {
+            (true, true) => {
+                quote_spanned!(span=>
+                    impl #impl_generics #ident #ty_generics #where_clause {
+                        /// Returns an instance with default values applied.
+                        #[allow(clippy::new_without_default)]
+                        #[allow(clippy::semicolon_if_nothing_returned)]
+                        #[must_use]
+                        pub const fn new() -> Self {
+                            Self {
+                                bytes: <Self as ::modular_bitfield::Specifier>::DEFAULT.to_le_bytes()
+                            }
+                        }
+
+                        /// Returns an instance with all bits initialized to zero.
+                        #[must_use]
+                        pub const fn new_zeroed() -> Self {
+                            Self {
+                                bytes: [0_u8; #byte_count]
+                            }
+                        }
                     }
-                }
+                )
             }
-        )
+            (true, false) => {
+                let const_bytes_init = self.generate_const_default_bytes(config, &byte_count);
+
+                quote_spanned!(span=>
+                    impl #impl_generics #ident #ty_generics #where_clause {
+                        /// Returns an instance with default values applied.
+                        #[allow(clippy::new_without_default)]
+                        #[allow(clippy::semicolon_if_nothing_returned)]
+                        #[must_use]
+                        pub const fn new() -> Self {
+                            Self {
+                                bytes: #const_bytes_init
+                            }
+                        }
+
+                        /// Returns an instance with all bits initialized to zero.
+                        #[must_use]
+                        pub const fn new_zeroed() -> Self {
+                            Self {
+                                bytes: [0_u8; #byte_count]
+                            }
+                        }
+                    }
+                )
+            }
+            (false, _) => {
+                quote_spanned!(span=>
+                    impl #impl_generics #ident #ty_generics #where_clause {
+                        /// Returns an instance with zero initialized data.
+                        #[allow(clippy::new_without_default)]
+                        #[must_use]
+                        pub const fn new() -> Self {
+                            Self {
+                                bytes: [0_u8; #byte_count]
+                            }
+                        }
+                    }
+                )
+            }
+        }
     }
 
     /// Generates the compile-time assertion if the optional `byte` parameter has been set.
@@ -514,7 +611,7 @@ impl BitfieldStruct {
             field,
             config,
         } = info;
-        if config.skip_getters() {
+        if config.skip_getters().is_some() {
             return None;
         }
         let struct_ident = &self.item_struct.ident;
@@ -580,7 +677,7 @@ impl BitfieldStruct {
             field,
             config,
         } = info;
-        if config.skip_setters() {
+        if config.skip_setters().is_some() {
             return None;
         }
         let struct_ident = &self.item_struct.ident;
@@ -725,5 +822,82 @@ impl BitfieldStruct {
                 #( #setters_and_getters )*
             }
         )
+    }
+
+    /// Generates a const expression that creates a byte array with default values applied.
+    /// This uses const-compatible bit manipulation to set default values at compile time.
+    fn generate_const_default_bytes(
+        &self,
+        config: &Config,
+        byte_count: &TokenStream2,
+    ) -> TokenStream2 {
+        let span = self.item_struct.span();
+
+        let mut bit_manipulations = Vec::new();
+        let mut current_offset = quote_spanned!(span=> 0usize);
+
+        for info in self.field_infos(config) {
+            let field_type = &info.field.ty;
+            let field_bits = quote_spanned!(span=> <#field_type as ::modular_bitfield::Specifier>::BITS);
+
+            let field_config = &info.config;
+            let const_value = if let Some(default_config) = &field_config.default {
+                let default_value = &default_config.value;
+                let span = default_config.span;
+                quote_spanned!(span=> {
+                    #default_value as <#field_type as ::modular_bitfield::Specifier>::Bytes
+                })
+            } else {
+                quote_spanned!(span=> <#field_type as ::modular_bitfield::Specifier>::DEFAULT)
+            };
+
+            let bit_manipulation = quote_spanned!(span=>
+                let field_offset = #current_offset;
+                let field_value = #const_value;
+                let field_bits = #field_bits;
+
+                let mut remaining_bits = field_bits;
+                #[allow(clippy::unnecessary_cast)]
+                let mut value = field_value as u128;
+                let mut byte_idx = field_offset / 8;
+                let mut bit_pos = field_offset % 8;
+
+                while remaining_bits > 0 {
+                    let bits_in_this_byte = if bit_pos + remaining_bits <= 8 {
+                        remaining_bits
+                    } else {
+                        8 - bit_pos
+                    };
+
+                    if bits_in_this_byte == 8 && bit_pos == 0 {
+                        bytes[byte_idx] = (value & 0xFF) as u8;
+                    } else {
+                        let byte_value = ((value & 0xFF) as u8) << bit_pos;
+                        bytes[byte_idx] |= byte_value;
+                    }
+
+                    value >>= bits_in_this_byte;
+                    remaining_bits -= bits_in_this_byte;
+                    byte_idx += 1;
+                    bit_pos = 0;
+                }
+            );
+
+            bit_manipulations.push(bit_manipulation);
+            current_offset = quote_spanned!(span=> #current_offset + #field_bits);
+        }
+
+        if bit_manipulations.is_empty() {
+            quote_spanned!(span=> [0u8; #byte_count])
+        } else {
+            quote_spanned!(span=> {
+                #[allow(clippy::semicolon_if_nothing_returned)]
+                {
+                    let mut bytes = [0u8; #byte_count];
+                    #( #bit_manipulations )*
+                    bytes
+                }
+            })
+        }
     }
 }

--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -833,7 +833,7 @@ impl BitfieldStruct {
     ) -> TokenStream2 {
         let span = self.item_struct.span();
 
-        let mut bit_manipulations = Vec::new();
+        let mut defaults = Vec::new();
         let mut current_offset = quote_spanned!(span=> 0usize);
 
         for info in self.field_infos(config) {
@@ -871,9 +871,9 @@ impl BitfieldStruct {
                     };
 
                     if bits_in_this_byte == 8 && bit_pos == 0 {
-                        bytes[byte_idx] = (value & 0xFF) as u8;
+                        bytes[byte_idx] = value as u8;
                     } else {
-                        let byte_value = ((value & 0xFF) as u8) << bit_pos;
+                        let byte_value = (value as u8) << bit_pos;
                         bytes[byte_idx] |= byte_value;
                     }
 
@@ -884,21 +884,17 @@ impl BitfieldStruct {
                 }
             );
 
-            bit_manipulations.push(bit_manipulation);
+            defaults.push(bit_manipulation);
             current_offset = quote_spanned!(span=> #current_offset + #field_bits);
         }
 
-        if bit_manipulations.is_empty() {
-            quote_spanned!(span=> [0u8; #byte_count])
-        } else {
-            quote_spanned!(span=> {
-                #[allow(clippy::semicolon_if_nothing_returned)]
-                {
-                    let mut bytes = [0u8; #byte_count];
-                    #( #bit_manipulations )*
-                    bytes
-                }
-            })
-        }
+        quote_spanned!(span=> {
+            #[allow(clippy::semicolon_if_nothing_returned)]
+            {
+                let mut bytes = [0u8; #byte_count];
+                #( #defaults )*
+                bytes
+            }
+        })
     }
 }

--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -852,49 +852,24 @@ impl BitfieldStruct {
                 quote_spanned!(span=> <#field_type as ::modular_bitfield::Specifier>::DEFAULT)
             };
 
-            let bit_manipulation = quote_spanned!(span=>
-                let field_offset = #current_offset;
-                let field_value = #const_value;
-                let field_bits = #field_bits;
-
-                let mut remaining_bits = field_bits;
-                #[allow(clippy::unnecessary_cast)]
-                let mut value = field_value as u128;
-                let mut byte_idx = field_offset / 8;
-                let mut bit_pos = field_offset % 8;
-
-                while remaining_bits > 0 {
-                    let bits_in_this_byte = if bit_pos + remaining_bits <= 8 {
-                        remaining_bits
-                    } else {
-                        8 - bit_pos
-                    };
-
-                    if bits_in_this_byte == 8 && bit_pos == 0 {
-                        bytes[byte_idx] = value as u8;
-                    } else {
-                        let byte_value = (value as u8) << bit_pos;
-                        bytes[byte_idx] |= byte_value;
-                    }
-
-                    value >>= bits_in_this_byte;
-                    remaining_bits -= bits_in_this_byte;
-                    byte_idx += 1;
-                    bit_pos = 0;
-                }
+            let default_call = quote_spanned!(span=>
+                #[allow(clippy::identity_op, clippy::unnecessary_cast)]
+                let bytes = ::modular_bitfield::private::set_bits_in_bytes(
+                    bytes,
+                    #current_offset,
+                    #const_value as u128,
+                    #field_bits,
+                );
             );
 
-            defaults.push(bit_manipulation);
+            defaults.push(default_call);
             current_offset = quote_spanned!(span=> #current_offset + #field_bits);
         }
 
         quote_spanned!(span=> {
-            #[allow(clippy::semicolon_if_nothing_returned)]
-            {
-                let mut bytes = [0u8; #byte_count];
-                #( #defaults )*
-                bytes
-            }
+            let bytes = [0u8; #byte_count];
+            #( #defaults )*
+            bytes
         })
     }
 }

--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -834,7 +834,7 @@ impl BitfieldStruct {
         let span = self.item_struct.span();
 
         let mut defaults = Vec::new();
-        let mut current_offset = quote_spanned!(span=> 0usize);
+        let mut offset = Punctuated::<syn::Expr, Token![+]>::new();
 
         for info in self.field_infos(config) {
             let field_type = &info.field.ty;
@@ -852,6 +852,12 @@ impl BitfieldStruct {
                 quote_spanned!(span=> <#field_type as ::modular_bitfield::Specifier>::DEFAULT)
             };
 
+            let current_offset = if offset.is_empty() {
+                quote_spanned!(span=> 0usize)
+            } else {
+                offset.to_token_stream()
+            };
+
             let default_call = quote_spanned!(span=>
                 #[allow(clippy::identity_op, clippy::unnecessary_cast)]
                 let bytes = ::modular_bitfield::private::set_bits_in_bytes(
@@ -863,7 +869,9 @@ impl BitfieldStruct {
             );
 
             defaults.push(default_call);
-            current_offset = quote_spanned!(span=> #current_offset + #field_bits);
+            offset.push(syn::parse_quote_spanned!(span=>
+                <#field_type as ::modular_bitfield::Specifier>::BITS
+            ));
         }
 
         quote_spanned!(span=> {

--- a/impl/src/bitfield/field_info.rs
+++ b/impl/src/bitfield/field_info.rs
@@ -63,7 +63,7 @@ impl BitfieldStruct {
                 .get(&n)
                 .map(|config| &config.value)
                 .cloned()
-                .unwrap_or_default();
+                .unwrap_or_else(FieldConfig::new);
             FieldInfo::new(n, field, field_config)
         })
     }

--- a/impl/src/bitfield_specifier.rs
+++ b/impl/src/bitfield_specifier.rs
@@ -127,6 +127,7 @@ fn generate_enum(input: &syn::ItemEnum) -> syn::Result<TokenStream2> {
 
         impl #impl_generics ::modular_bitfield::Specifier for #enum_ident #ty_generics #where_clause {
             const BITS: ::core::primitive::usize = #bits;
+            const DEFAULT: Self::Bytes = 0;
             type Bytes = <::modular_bitfield::private::checks::BitCount<#bits> as ::modular_bitfield::private::SpecifierBytes>::Bytes;
             type InOut = Self;
 

--- a/impl/src/define_specifiers.rs
+++ b/impl/src/define_specifiers.rs
@@ -37,6 +37,7 @@ fn generate_specifier_for(bits: usize) -> TokenStream2 {
 
         impl crate::Specifier for #ident {
             const BITS: usize = #bits;
+            const DEFAULT: Self::Bytes = 0;
             type Bytes = #in_out;
             type InOut = #in_out;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,12 @@ pub trait Specifier {
     /// The number of bits used by the `Specifier`.
     const BITS: usize;
 
+    /// The default value for this specifier type.
+    ///
+    /// This is used when constructing parent bitfields to properly initialize
+    /// fields that have their own defaults.
+    const DEFAULT: Self::Bytes;
+
     /// The storage type. This is typically the smallest integer primitive that
     /// can store all possible values of the [`InOut`](Self::InOut) type.
     type Bytes;

--- a/src/private/impls.rs
+++ b/src/private/impls.rs
@@ -5,6 +5,7 @@ use crate::{
 
 impl Specifier for bool {
     const BITS: usize = 1;
+    const DEFAULT: Self::Bytes = 0;
     type Bytes = u8;
     type InOut = bool;
 
@@ -28,6 +29,7 @@ macro_rules! impl_specifier_for_primitive {
         $(
             impl Specifier for $prim {
                 const BITS: usize = $bits;
+                const DEFAULT: Self::Bytes = 0;
                 type Bytes = $prim;
                 type InOut = $prim;
 

--- a/src/private/mod.rs
+++ b/src/private/mod.rs
@@ -10,7 +10,7 @@ pub mod static_assertions {
 }
 pub use self::{
     array_bytes_conv::ArrayBytesConversion,
-    proc::{read_specifier, write_specifier},
+    proc::{read_specifier, set_bits_in_bytes, write_specifier},
     push_pop::{PopBuffer, PushBuffer},
     traits::{
         IsU128Compatible, IsU16Compatible, IsU32Compatible, IsU64Compatible, IsU8Compatible,

--- a/src/private/proc.rs
+++ b/src/private/proc.rs
@@ -117,3 +117,37 @@ where
         }
     }
 }
+
+#[doc(hidden)]
+#[inline]
+#[must_use]
+pub const fn set_bits_in_bytes<const N: usize>(
+    mut bytes: [u8; N],
+    offset: usize,
+    value: u128,
+    bits: usize,
+) -> [u8; N] {
+    let mut remaining_bits = bits;
+    let mut value = value;
+    let mut byte_idx = offset / 8;
+    let mut bit_pos = offset % 8;
+    while remaining_bits > 0 {
+        let bits_in_this_byte = if bit_pos + remaining_bits <= 8 {
+            remaining_bits
+        } else {
+            8 - bit_pos
+        };
+
+        #[allow(clippy::cast_possible_truncation)]
+        if bits_in_this_byte == 8 && bit_pos == 0 {
+            bytes[byte_idx] = value as u8;
+        } else {
+            bytes[byte_idx] |= (value as u8) << bit_pos;
+        }
+        value >>= bits_in_this_byte;
+        remaining_bits -= bits_in_this_byte;
+        byte_idx += 1;
+        bit_pos = 0;
+    }
+    bytes
+}

--- a/tests/bitfield/default.rs
+++ b/tests/bitfield/default.rs
@@ -1,0 +1,295 @@
+use modular_bitfield::prelude::*;
+
+#[test]
+fn basic_defaults() {
+    #[bitfield]
+    pub struct BasicDefaults {
+        foo: bool,
+        #[default = false]
+        bar: bool,
+        baz: B6,
+        #[default = 42]
+        qux: B8,
+    }
+
+    let bf = BasicDefaults::new();
+    assert!(!bf.foo()); // no default
+    assert!(!bf.bar()); // explicit false
+    assert_eq!(bf.baz(), 0); // no default
+    assert_eq!(bf.qux(), 42); // explicit default
+}
+
+#[test]
+fn all_primitive_types() {
+    #[bitfield]
+    pub struct PrimitiveDefaults {
+        #[default = true]
+        flag: bool,
+        #[default = 0b11]
+        two_bits: B2,
+        #[default = 0x1F]
+        padding: B5,
+        #[default = 0xFF]
+        byte: B8,
+        #[default = 0x1234]
+        word: B16,
+    }
+
+    let bf = PrimitiveDefaults::new();
+    assert!(bf.flag());
+    assert_eq!(bf.two_bits(), 0b11);
+    assert_eq!(bf.padding(), 0x1F);
+    assert_eq!(bf.byte(), 0xFF);
+    assert_eq!(bf.word(), 0x1234);
+}
+
+#[test]
+fn enum_defaults() {
+    #[derive(Debug, Clone, Copy, PartialEq, Specifier)]
+    #[bits = 2]
+    pub enum Mode {
+        Off = 0,
+        On = 1,
+        Auto = 2,
+    }
+
+    #[bitfield]
+    pub struct EnumDefaults {
+        #[default = Mode::Auto]
+        mode: Mode,
+        #[default = true]
+        enabled: bool,
+        padding: B5,
+    }
+
+    let bf = EnumDefaults::new();
+    assert_eq!(bf.mode(), Mode::Auto);
+    assert!(bf.enabled());
+    assert_eq!(bf.padding(), 0);
+}
+
+#[test]
+fn nested_bitfield_defaults() {
+    #[bitfield(bits = 4)]
+    #[derive(Debug, Clone, Copy, PartialEq, Specifier)]
+    pub struct Nibble {
+        #[default = 0xF]
+        value: B4,
+    }
+
+    #[bitfield]
+    pub struct Parent {
+        nibble: Nibble,
+        #[default = 0xAB]
+        data: B12,
+    }
+
+    let parent = Parent::new();
+    assert_eq!(parent.nibble().value(), 0xF); // Uses Nibble's default
+    assert_eq!(parent.data(), 0xAB);
+}
+
+#[test]
+fn nested_specifier_defaults() {
+    #[bitfield(bits = 8)]
+    #[derive(Debug, Clone, Copy, PartialEq, Specifier)]
+    pub struct Flags {
+        #[default = true]
+        enabled: bool,
+        #[default = false]
+        debug: bool,
+        #[default = 0b11111]
+        level: B6,
+    }
+
+    #[bitfield]
+    pub struct Config {
+        flags: Flags,
+        #[default = 0x42]
+        data: B8,
+    }
+
+    let config = Config::new();
+    let flags = config.flags();
+    assert!(flags.enabled());
+    assert!(!flags.debug());
+    assert_eq!(flags.level(), 0b11111);
+    assert_eq!(config.data(), 0x42);
+}
+
+#[test]
+#[allow(clippy::wrong_self_convention)]
+fn const_expressions() {
+    const DEFAULT_VALUE: u8 = 42;
+
+    #[bitfield]
+    pub struct ConstDefaults {
+        #[default = 1 + 2]
+        sum: B4,
+        #[default = DEFAULT_VALUE]
+        from_const: B8,
+        #[default = 0xFF & 0x0F]
+        masked: B4,
+    }
+
+    let bf = ConstDefaults::new();
+    assert_eq!(bf.sum(), 3);
+    assert_eq!(bf.from_const(), 42);
+    assert_eq!(bf.masked(), 0x0F);
+}
+
+#[test]
+fn derive_default_trait() {
+    #[bitfield]
+    #[derive(Default, PartialEq, Debug)]
+    pub struct DeriveDefault {
+        #[default = true]
+        flag: bool,
+        #[default = 123]
+        value: B8,
+        counter: B7, // no default
+    }
+
+    let default_bf = DeriveDefault::default();
+    let new_bf = DeriveDefault::new();
+
+    // Default trait should match new()
+    assert_eq!(default_bf, new_bf);
+    assert!(default_bf.flag());
+    assert_eq!(default_bf.value(), 123);
+    assert_eq!(default_bf.counter(), 0);
+}
+
+#[test]
+fn defaults_with_skip() {
+    #[bitfield]
+    pub struct SkipDefaults {
+        #[default = 42]
+        #[skip(setters)]
+        readonly: B8,
+        #[default = true]
+        #[skip]
+        _reserved: bool,
+        #[default = 0x7]
+        data: B7,
+    }
+
+    let bf = SkipDefaults::new();
+    assert_eq!(bf.readonly(), 42);
+    assert_eq!(bf.data(), 0x7);
+
+    // Verify readonly field has no setter
+    let bf2 = bf.with_data(0x5);
+    assert_eq!(bf2.readonly(), 42); // unchanged
+    assert_eq!(bf2.data(), 0x5);
+}
+
+#[test]
+fn new_zeroed_ignores_defaults() {
+    #[bitfield]
+    pub struct ZeroedTest {
+        #[default = true]
+        flag: bool,
+        #[default = 0xFF]
+        value: B8,
+        padding: B7,
+    }
+
+    let zeroed = ZeroedTest::new_zeroed();
+    assert!(!zeroed.flag());
+    assert_eq!(zeroed.value(), 0);
+    assert_eq!(zeroed.padding(), 0);
+}
+
+#[test]
+fn specifier_default_matches_constructor() {
+    #[bitfield(bits = 8)]
+    #[derive(Debug, Clone, Copy, PartialEq, Specifier)]
+    struct TestBitfield {
+        #[default = true]
+        flag: bool,
+        #[default = 0x7]
+        value: B7,
+    }
+
+    let instance = TestBitfield::new();
+    let from_default = TestBitfield::from_bytes(TestBitfield::DEFAULT.to_le_bytes());
+
+    assert_eq!(instance.into_bytes(), from_default.into_bytes());
+}
+
+#[test]
+fn cross_byte_boundary() {
+    #[bitfield]
+    pub struct CrossByte {
+        #[default = 0x3]
+        prefix: B2,
+        #[default = 0x3FF]
+        middle: B10, // Crosses byte boundary
+        #[default = 0xF]
+        suffix: B4,
+    }
+
+    let bf = CrossByte::new();
+    assert_eq!(bf.prefix(), 0x3);
+    assert_eq!(bf.middle(), 0x3FF);
+    assert_eq!(bf.suffix(), 0xF);
+}
+
+#[test]
+fn tuple_struct_defaults() {
+    #[bitfield]
+    pub struct TupleDefaults(
+        #[default = true] bool,
+        #[default = 255] B8,
+        B7, // no default
+    );
+
+    let bf = TupleDefaults::new();
+    assert!(bf.get_0());
+    assert_eq!(bf.get_1(), 255);
+    assert_eq!(bf.get_2(), 0);
+}
+
+#[test]
+fn const_context_usage() {
+    #[bitfield]
+    pub struct ConstBitfield {
+        #[default = 0xFF]
+        value: B8,
+        #[default = true]
+        flag: bool,
+        padding: B7,
+    }
+
+    const STATIC_BF: ConstBitfield = ConstBitfield::new();
+    assert_eq!(STATIC_BF.value(), 0xFF);
+    assert!(STATIC_BF.flag());
+}
+
+#[test]
+fn max_value_defaults() {
+    #[bitfield]
+    pub struct MaxValues {
+        #[default = 0x7F]
+        seven_bits: B7,
+        #[default = 0xFFFF]
+        sixteen_bits: B16,
+        #[default = true]
+        flag: bool,
+        #[default = 0xFF]
+        byte: B8,
+        #[default = 0xFFFF_FFFF_FFFF_FFFF]
+        large: B64,
+        #[default = 0x1234_5678_9ABC_DEF0_1234_5678_9ABC_DEF0]
+        huge: B128,
+    }
+
+    let bf = MaxValues::new();
+    assert_eq!(bf.seven_bits(), 0x7F);
+    assert_eq!(bf.sixteen_bits(), 0xFFFF);
+    assert!(bf.flag());
+    assert_eq!(bf.byte(), 0xFF);
+    assert_eq!(bf.large(), 0xFFFF_FFFF_FFFF_FFFF);
+    assert_eq!(bf.huge(), 0x1234_5678_9ABC_DEF0_1234_5678_9ABC_DEF0);
+}

--- a/tests/bitfield/derive_bitfield_specifier.rs
+++ b/tests/bitfield/derive_bitfield_specifier.rs
@@ -114,8 +114,8 @@ fn enums() {
 fn name_conflict() {
     #[derive(Specifier)]
     pub enum SuspiciouslyAmbiguous {
-        Bytes,
-        InOut,
+        BytesVariant,
+        InOutVariant,
     }
 }
 

--- a/tests/bitfield/derive_default.rs
+++ b/tests/bitfield/derive_default.rs
@@ -1,0 +1,173 @@
+use modular_bitfield::prelude::*;
+
+#[test]
+fn basic_default_without_field_defaults() {
+    #[bitfield]
+    #[derive(Default, PartialEq, Debug)]
+    pub struct BasicBitfield {
+        flag: bool,
+        value: B8,
+        counter: B4,
+        enabled: bool,
+        padding: B2,
+    }
+
+    let default_bf = BasicBitfield::default();
+    let new_bf = BasicBitfield::new();
+
+    // Default should be identical to new()
+    assert_eq!(default_bf, new_bf);
+
+    // All fields should be zero-initialized
+    assert!(!default_bf.flag());
+    assert_eq!(default_bf.value(), 0);
+    assert_eq!(default_bf.counter(), 0);
+    assert!(!default_bf.enabled());
+    assert_eq!(default_bf.padding(), 0);
+}
+
+#[test]
+fn default_with_field_defaults() {
+    #[bitfield]
+    #[derive(Default, PartialEq, Debug)]
+    pub struct WithFieldDefaults {
+        #[default = true]
+        flag: bool,
+        #[default = 42]
+        value: B8,
+        counter: B4, // no default
+        #[default = false]
+        enabled: bool,
+        #[default = 3]
+        padding: B2,
+    }
+
+    let default_bf = WithFieldDefaults::default();
+    let new_bf = WithFieldDefaults::new();
+
+    // Default should be identical to new()
+    assert_eq!(default_bf, new_bf);
+
+    // Fields with defaults should use default values
+    assert!(default_bf.flag());
+    assert_eq!(default_bf.value(), 42);
+    assert_eq!(default_bf.counter(), 0); // no default, so zero
+    assert!(!default_bf.enabled());
+    assert_eq!(default_bf.padding(), 3);
+}
+
+#[test]
+fn default_with_enum_fields() {
+    #[derive(Debug, Clone, Copy, PartialEq, Specifier)]
+    #[bits = 2]
+    pub enum Status {
+        Idle = 0,
+        Running = 1,
+        Paused = 2,
+        Error = 3,
+    }
+
+    #[bitfield]
+    #[derive(Default, PartialEq, Debug)]
+    pub struct WithEnumDefaults {
+        #[default = Status::Running]
+        status: Status,
+        #[default = true]
+        enabled: bool,
+        counter: B5, // no default
+    }
+
+    let default_bf = WithEnumDefaults::default();
+    let new_bf = WithEnumDefaults::new();
+
+    // Default should be identical to new()
+    assert_eq!(default_bf, new_bf);
+
+    // Check field values
+    assert_eq!(default_bf.status(), Status::Running);
+    assert!(default_bf.enabled());
+    assert_eq!(default_bf.counter(), 0); // no default, so zero
+}
+
+#[test]
+fn default_tuple_struct() {
+    #[bitfield]
+    #[derive(Default, PartialEq, Debug)]
+    pub struct TupleBitfield(
+        #[default = true] bool,
+        #[default = 255] B8,
+        B4, // no default
+        #[default = false] bool,
+        B2, // padding to make it 16 bits total
+    );
+
+    let default_bf = TupleBitfield::default();
+    let new_bf = TupleBitfield::new();
+
+    // Default should be identical to new()
+    assert_eq!(default_bf, new_bf);
+
+    // Check field values
+    assert!(default_bf.get_0());
+    assert_eq!(default_bf.get_1(), 255);
+    assert_eq!(default_bf.get_2(), 0); // no default, so zero
+    assert!(!default_bf.get_3());
+    assert_eq!(default_bf.get_4(), 0); // no default, so zero
+}
+
+#[test]
+fn default_with_complex_expressions() {
+    const DEFAULT_VALUE: u8 = 42;
+
+    #[bitfield]
+    #[derive(Default, PartialEq, Debug)]
+    pub struct ComplexDefaults {
+        #[default = 1 + 2]
+        a: B4,
+        #[default = DEFAULT_VALUE]
+        b: B8,
+        #[default = 0xFF & 0x0F]
+        c: B4,
+    }
+
+    let default_bf = ComplexDefaults::default();
+    let new_bf = ComplexDefaults::new();
+
+    // Default should be identical to new()
+    assert_eq!(default_bf, new_bf);
+
+    // Check field values
+    assert_eq!(default_bf.a(), 3); // 1 + 2
+    assert_eq!(default_bf.b(), DEFAULT_VALUE);
+    assert_eq!(default_bf.c(), 0x0F); // 0xFF & 0x0F
+}
+
+#[test]
+fn default_preserves_other_derives() {
+    extern crate alloc;
+    use alloc::format;
+
+    #[bitfield]
+    #[derive(Default, Debug, Clone, PartialEq, Eq)]
+    pub struct MultiDerive {
+        #[default = true]
+        flag: bool,
+        #[default = 123]
+        value: B8,
+        #[default = 127]
+        padding: B7,
+    }
+
+    let default_bf = MultiDerive::default();
+    let cloned_bf = default_bf.clone();
+
+    // Test that all derives work
+    assert_eq!(default_bf, cloned_bf);
+    // Test Debug implementation works
+    let _debug_str = format!("{default_bf:?}");
+
+    // Check values
+    assert!(default_bf.flag());
+    assert_eq!(default_bf.value(), 123);
+    assert_eq!(default_bf.padding(), 127);
+}

--- a/tests/bitfield/mod.rs
+++ b/tests/bitfield/mod.rs
@@ -1,7 +1,9 @@
 mod bits_param;
 mod bytes_param;
+mod default;
 mod derive_bitfield_specifier;
 mod derive_debug;
+mod derive_default;
 mod derive_specifier;
 mod filled_param;
 mod no_implicit_prelude;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -2,5 +2,6 @@
 #![deny(elided_lifetimes_in_paths)]
 #![warn(clippy::pedantic, rust_2018_idioms)]
 #![allow(dead_code)]
+#![allow(clippy::semicolon_if_nothing_returned)]
 
 mod bitfield;

--- a/tests/ui/bits_attribute_wrong.stderr
+++ b/tests/ui/bits_attribute_wrong.stderr
@@ -4,13 +4,13 @@ error: encountered invalid value type for #[bits = N]
 20 |     #[bits = NOT_A_LITERAL]
    |              ^^^^^^^^^^^^^
 
-error: encountered duplicate `#[bits = N]` attribute for field
+error: encountered duplicate `#[bits = ...]` attribute for field
   --> tests/ui/bits_attribute_wrong.rs:28:7
    |
 28 |     #[bits = 1]
    |       ^^^^
 
-error: duplicate `#[bits = N]` here
+error: duplicate `#[bits = ...]` here
   --> tests/ui/bits_attribute_wrong.rs:27:7
    |
 27 |     #[bits = 1]

--- a/tests/ui/bits_param/too_few_bits.stderr
+++ b/tests/ui/bits_param/too_few_bits.stderr
@@ -1,42 +1,42 @@
 error[E0277]: the trait bound `False: FillsUnalignedBits` is not satisfied
  --> tests/ui/bits_param/too_few_bits.rs:4:1
   |
-  4 | pub struct SignInteger {
-    | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
-    |
+4 | pub struct SignInteger {
+  | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
+  |
 help: the trait `FillsUnalignedBits` is implemented for `True`
-   --> src/private/checks.rs
-    |
-    | impl FillsUnalignedBits for True {}
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> src/private/checks.rs
+  |
+  | impl FillsUnalignedBits for True {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckFillsUnalignedBits::CheckType`
-   --> src/private/checks.rs
-    |
-    |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
-    |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits::CheckType`
-    | {
-    |     type CheckType: DispatchTrueFalse;
-    |          --------- required by a bound in this associated type
+ --> src/private/checks.rs
+  |
+  |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
+  |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits::CheckType`
+  | {
+  |     type CheckType: DispatchTrueFalse;
+  |          --------- required by a bound in this associated type
 
 error[E0277]: the trait bound `False: FillsUnalignedBits` is not satisfied
  --> tests/ui/bits_param/too_few_bits.rs:4:1
   |
-  4 | pub struct SignInteger {
-    | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
-    |
+4 | pub struct SignInteger {
+  | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
+  |
 help: the trait `FillsUnalignedBits` is implemented for `True`
-   --> src/private/checks.rs
-    |
-    | impl FillsUnalignedBits for True {}
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> src/private/checks.rs
+  |
+  | impl FillsUnalignedBits for True {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckFillsUnalignedBits`
-   --> src/private/checks.rs
-    |
-    | pub trait CheckFillsUnalignedBits
-    |           ----------------------- required by a bound in this trait
-    | where
-    |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
-    |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits`
-    = note: `CheckFillsUnalignedBits` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::FillsUnalignedBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-    = help: the following type implements the trait:
-              modular_bitfield::private::checks::True
+ --> src/private/checks.rs
+  |
+  | pub trait CheckFillsUnalignedBits
+  |           ----------------------- required by a bound in this trait
+  | where
+  |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
+  |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits`
+  = note: `CheckFillsUnalignedBits` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::FillsUnalignedBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+  = help: the following type implements the trait:
+            modular_bitfield::private::checks::True

--- a/tests/ui/bits_param/too_few_bits.stderr
+++ b/tests/ui/bits_param/too_few_bits.stderr
@@ -1,34 +1,42 @@
 error[E0277]: the trait bound `False: FillsUnalignedBits` is not satisfied
  --> tests/ui/bits_param/too_few_bits.rs:4:1
   |
-4 | pub struct SignInteger {
-  | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
-  |
-  = help: the trait `FillsUnalignedBits` is implemented for `True`
+  4 | pub struct SignInteger {
+    | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
+    |
+help: the trait `FillsUnalignedBits` is implemented for `True`
+   --> src/private/checks.rs
+    |
+    | impl FillsUnalignedBits for True {}
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckFillsUnalignedBits::CheckType`
- --> src/private/checks.rs
-  |
-  |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
-  |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits::CheckType`
-  | {
-  |     type CheckType: DispatchTrueFalse;
-  |          --------- required by a bound in this associated type
+   --> src/private/checks.rs
+    |
+    |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
+    |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits::CheckType`
+    | {
+    |     type CheckType: DispatchTrueFalse;
+    |          --------- required by a bound in this associated type
 
 error[E0277]: the trait bound `False: FillsUnalignedBits` is not satisfied
  --> tests/ui/bits_param/too_few_bits.rs:4:1
   |
-4 | pub struct SignInteger {
-  | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
-  |
-  = help: the trait `FillsUnalignedBits` is implemented for `True`
+  4 | pub struct SignInteger {
+    | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
+    |
+help: the trait `FillsUnalignedBits` is implemented for `True`
+   --> src/private/checks.rs
+    |
+    | impl FillsUnalignedBits for True {}
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckFillsUnalignedBits`
- --> src/private/checks.rs
-  |
-  | pub trait CheckFillsUnalignedBits
-  |           ----------------------- required by a bound in this trait
-  | where
-  |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
-  |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits`
-  = note: `CheckFillsUnalignedBits` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::FillsUnalignedBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-  = help: the following type implements the trait:
-            modular_bitfield::private::checks::True
+   --> src/private/checks.rs
+    |
+    | pub trait CheckFillsUnalignedBits
+    |           ----------------------- required by a bound in this trait
+    | where
+    |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
+    |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits`
+    = note: `CheckFillsUnalignedBits` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::FillsUnalignedBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+    = help: the following type implements the trait:
+              modular_bitfield::private::checks::True

--- a/tests/ui/bits_param/too_many_bits.stderr
+++ b/tests/ui/bits_param/too_many_bits.stderr
@@ -1,34 +1,42 @@
 error[E0277]: the trait bound `False: FillsUnalignedBits` is not satisfied
  --> tests/ui/bits_param/too_many_bits.rs:4:1
   |
-4 | pub struct SignInteger {
-  | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
-  |
-  = help: the trait `FillsUnalignedBits` is implemented for `True`
+  4 | pub struct SignInteger {
+    | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
+    |
+help: the trait `FillsUnalignedBits` is implemented for `True`
+   --> src/private/checks.rs
+    |
+    | impl FillsUnalignedBits for True {}
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckFillsUnalignedBits::CheckType`
- --> src/private/checks.rs
-  |
-  |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
-  |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits::CheckType`
-  | {
-  |     type CheckType: DispatchTrueFalse;
-  |          --------- required by a bound in this associated type
+   --> src/private/checks.rs
+    |
+    |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
+    |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits::CheckType`
+    | {
+    |     type CheckType: DispatchTrueFalse;
+    |          --------- required by a bound in this associated type
 
 error[E0277]: the trait bound `False: FillsUnalignedBits` is not satisfied
  --> tests/ui/bits_param/too_many_bits.rs:4:1
   |
-4 | pub struct SignInteger {
-  | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
-  |
-  = help: the trait `FillsUnalignedBits` is implemented for `True`
+  4 | pub struct SignInteger {
+    | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
+    |
+help: the trait `FillsUnalignedBits` is implemented for `True`
+   --> src/private/checks.rs
+    |
+    | impl FillsUnalignedBits for True {}
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckFillsUnalignedBits`
- --> src/private/checks.rs
-  |
-  | pub trait CheckFillsUnalignedBits
-  |           ----------------------- required by a bound in this trait
-  | where
-  |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
-  |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits`
-  = note: `CheckFillsUnalignedBits` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::FillsUnalignedBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-  = help: the following type implements the trait:
-            modular_bitfield::private::checks::True
+   --> src/private/checks.rs
+    |
+    | pub trait CheckFillsUnalignedBits
+    |           ----------------------- required by a bound in this trait
+    | where
+    |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
+    |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits`
+    = note: `CheckFillsUnalignedBits` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::FillsUnalignedBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+    = help: the following type implements the trait:
+              modular_bitfield::private::checks::True

--- a/tests/ui/bits_param/too_many_bits.stderr
+++ b/tests/ui/bits_param/too_many_bits.stderr
@@ -1,42 +1,42 @@
 error[E0277]: the trait bound `False: FillsUnalignedBits` is not satisfied
  --> tests/ui/bits_param/too_many_bits.rs:4:1
   |
-  4 | pub struct SignInteger {
-    | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
-    |
+4 | pub struct SignInteger {
+  | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
+  |
 help: the trait `FillsUnalignedBits` is implemented for `True`
-   --> src/private/checks.rs
-    |
-    | impl FillsUnalignedBits for True {}
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> src/private/checks.rs
+  |
+  | impl FillsUnalignedBits for True {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckFillsUnalignedBits::CheckType`
-   --> src/private/checks.rs
-    |
-    |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
-    |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits::CheckType`
-    | {
-    |     type CheckType: DispatchTrueFalse;
-    |          --------- required by a bound in this associated type
+ --> src/private/checks.rs
+  |
+  |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
+  |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits::CheckType`
+  | {
+  |     type CheckType: DispatchTrueFalse;
+  |          --------- required by a bound in this associated type
 
 error[E0277]: the trait bound `False: FillsUnalignedBits` is not satisfied
  --> tests/ui/bits_param/too_many_bits.rs:4:1
   |
-  4 | pub struct SignInteger {
-    | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
-    |
+4 | pub struct SignInteger {
+  | ^^^ the trait `FillsUnalignedBits` is not implemented for `False`
+  |
 help: the trait `FillsUnalignedBits` is implemented for `True`
-   --> src/private/checks.rs
-    |
-    | impl FillsUnalignedBits for True {}
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> src/private/checks.rs
+  |
+  | impl FillsUnalignedBits for True {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckFillsUnalignedBits`
-   --> src/private/checks.rs
-    |
-    | pub trait CheckFillsUnalignedBits
-    |           ----------------------- required by a bound in this trait
-    | where
-    |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
-    |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits`
-    = note: `CheckFillsUnalignedBits` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::FillsUnalignedBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-    = help: the following type implements the trait:
-              modular_bitfield::private::checks::True
+ --> src/private/checks.rs
+  |
+  | pub trait CheckFillsUnalignedBits
+  |           ----------------------- required by a bound in this trait
+  | where
+  |     <Self::CheckType as DispatchTrueFalse>::Out: FillsUnalignedBits,
+  |                                                  ^^^^^^^^^^^^^^^^^^ required by this bound in `CheckFillsUnalignedBits`
+  = note: `CheckFillsUnalignedBits` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::FillsUnalignedBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+  = help: the following type implements the trait:
+            modular_bitfield::private::checks::True

--- a/tests/ui/default/bit_overflow.rs
+++ b/tests/ui/default/bit_overflow.rs
@@ -1,0 +1,9 @@
+use modular_bitfield::prelude::*;
+
+#[bitfield]
+pub struct BitOverflowTest {
+    #[default = -1]    // Negative value should fail
+    invalid: B8,
+}
+
+fn main() {}

--- a/tests/ui/default/bit_overflow.stderr
+++ b/tests/ui/default/bit_overflow.stderr
@@ -1,0 +1,12 @@
+error[E0600]: cannot apply unary operator `-` to type `u8`
+ --> tests/ui/default/bit_overflow.rs:5:17
+  |
+5 |     #[default = -1]    // Negative value should fail
+  |                 ^ cannot apply unary operator `-`
+  |
+  = note: unsigned values cannot be negated
+help: you may have meant the maximum value of `u8`
+  |
+5 -     #[default = -1]    // Negative value should fail
+5 +     #[u8::MAX1]    // Negative value should fail
+  |

--- a/tests/ui/default/const_overflow.rs
+++ b/tests/ui/default/const_overflow.rs
@@ -1,0 +1,9 @@
+use modular_bitfield::prelude::*;
+
+#[bitfield]
+pub struct OverflowTest {
+    #[default = 256]  // Too large for B8 (max 255)
+    overflow_b8: B8,
+}
+
+fn main() {}

--- a/tests/ui/default/const_overflow.stderr
+++ b/tests/ui/default/const_overflow.stderr
@@ -1,0 +1,8 @@
+error: literal out of range for `u8`
+ --> tests/ui/default/const_overflow.rs:5:17
+  |
+5 |     #[default = 256]  // Too large for B8 (max 255)
+  |                 ^^^
+  |
+  = note: the literal `256` does not fit into the type `u8` whose range is `0..=255`
+  = note: `#[deny(overflowing_literals)]` on by default

--- a/tests/ui/default/duplicate_default.rs
+++ b/tests/ui/default/duplicate_default.rs
@@ -1,0 +1,10 @@
+use modular_bitfield::prelude::*;
+
+#[bitfield]
+pub struct DuplicateDefault {
+    #[default = true]
+    #[default = false]
+    pub field: bool,
+}
+
+fn main() {}

--- a/tests/ui/default/duplicate_default.stderr
+++ b/tests/ui/default/duplicate_default.stderr
@@ -1,0 +1,11 @@
+error: encountered duplicate `#[default = ...]` attribute for field
+ --> tests/ui/default/duplicate_default.rs:6:7
+  |
+6 |     #[default = false]
+  |       ^^^^^^^
+
+error: duplicate `#[default = ...]` here
+ --> tests/ui/default/duplicate_default.rs:5:7
+  |
+5 |     #[default = true]
+  |       ^^^^^^^

--- a/tests/ui/default/invalid_default_format.rs
+++ b/tests/ui/default/invalid_default_format.rs
@@ -1,0 +1,10 @@
+use modular_bitfield::prelude::*;
+
+#[bitfield]
+pub struct InvalidDefaultFormat {
+    #[default]
+    pub field: bool,
+    pub other: B7,
+}
+
+fn main() {}

--- a/tests/ui/default/invalid_default_format.stderr
+++ b/tests/ui/default/invalid_default_format.stderr
@@ -1,0 +1,5 @@
+error: encountered invalid format for #[default] field attribute, expected #[default = expression]
+ --> tests/ui/default/invalid_default_format.rs:5:7
+  |
+5 |     #[default]
+  |       ^^^^^^^

--- a/tests/ui/default/non_const_default.rs
+++ b/tests/ui/default/non_const_default.rs
@@ -1,0 +1,13 @@
+use modular_bitfield::prelude::*;
+
+fn get_value() -> u8 {
+    42
+}
+
+#[bitfield]
+pub struct NonConstDefault {
+    #[default(get_value())]  // Function call not allowed in const context
+    field: B8,
+}
+
+fn main() {}

--- a/tests/ui/default/non_const_default.stderr
+++ b/tests/ui/default/non_const_default.stderr
@@ -1,0 +1,5 @@
+error: encountered invalid format for #[default] field attribute, expected #[default = expression]
+ --> tests/ui/default/non_const_default.rs:9:7
+  |
+9 |     #[default(get_value())]  // Function call not allowed in const context
+  |       ^^^^^^^

--- a/tests/ui/derive_bitfield_specifier/variant_out_of_range.stderr
+++ b/tests/ui/derive_bitfield_specifier/variant_out_of_range.stderr
@@ -1,34 +1,42 @@
 error[E0277]: the trait bound `False: DiscriminantInRange` is not satisfied
-  --> tests/ui/derive_bitfield_specifier/variant_out_of_range.rs:17:5
-   |
-17 |     External,
-   |     ^^^^^^^^ the trait `DiscriminantInRange` is not implemented for `False`
-   |
-   = help: the trait `DiscriminantInRange` is implemented for `True`
+ --> tests/ui/derive_bitfield_specifier/variant_out_of_range.rs:17:5
+  |
+ 17 |     External,
+    |     ^^^^^^^^ the trait `DiscriminantInRange` is not implemented for `False`
+    |
+help: the trait `DiscriminantInRange` is implemented for `True`
+   --> src/private/checks.rs
+    |
+    | impl DiscriminantInRange for True {}
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckDiscriminantInRange::CheckType`
-  --> src/private/checks.rs
-   |
-   |     <Self::CheckType as DispatchTrueFalse>::Out: DiscriminantInRange,
-   |                                                  ^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckDiscriminantInRange::CheckType`
-   | {
-   |     type CheckType: DispatchTrueFalse;
-   |          --------- required by a bound in this associated type
+   --> src/private/checks.rs
+    |
+    |     <Self::CheckType as DispatchTrueFalse>::Out: DiscriminantInRange,
+    |                                                  ^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckDiscriminantInRange::CheckType`
+    | {
+    |     type CheckType: DispatchTrueFalse;
+    |          --------- required by a bound in this associated type
 
 error[E0277]: the trait bound `False: DiscriminantInRange` is not satisfied
-  --> tests/ui/derive_bitfield_specifier/variant_out_of_range.rs:17:5
-   |
-17 |     External,
-   |     ^^^^^^^^ the trait `DiscriminantInRange` is not implemented for `False`
-   |
-   = help: the trait `DiscriminantInRange` is implemented for `True`
+ --> tests/ui/derive_bitfield_specifier/variant_out_of_range.rs:17:5
+  |
+ 17 |     External,
+    |     ^^^^^^^^ the trait `DiscriminantInRange` is not implemented for `False`
+    |
+help: the trait `DiscriminantInRange` is implemented for `True`
+   --> src/private/checks.rs
+    |
+    | impl DiscriminantInRange for True {}
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckDiscriminantInRange`
-  --> src/private/checks.rs
-   |
-   | pub trait CheckDiscriminantInRange<A>
-   |           ------------------------ required by a bound in this trait
-   | where
-   |     <Self::CheckType as DispatchTrueFalse>::Out: DiscriminantInRange,
-   |                                                  ^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckDiscriminantInRange`
-   = note: `CheckDiscriminantInRange` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::DiscriminantInRange`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-   = help: the following type implements the trait:
-             modular_bitfield::private::checks::True
+   --> src/private/checks.rs
+    |
+    | pub trait CheckDiscriminantInRange<A>
+    |           ------------------------ required by a bound in this trait
+    | where
+    |     <Self::CheckType as DispatchTrueFalse>::Out: DiscriminantInRange,
+    |                                                  ^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckDiscriminantInRange`
+    = note: `CheckDiscriminantInRange` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::DiscriminantInRange`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+    = help: the following type implements the trait:
+              modular_bitfield::private::checks::True

--- a/tests/ui/derive_bitfield_specifier/variant_out_of_range.stderr
+++ b/tests/ui/derive_bitfield_specifier/variant_out_of_range.stderr
@@ -1,42 +1,42 @@
 error[E0277]: the trait bound `False: DiscriminantInRange` is not satisfied
- --> tests/ui/derive_bitfield_specifier/variant_out_of_range.rs:17:5
-  |
- 17 |     External,
-    |     ^^^^^^^^ the trait `DiscriminantInRange` is not implemented for `False`
-    |
+  --> tests/ui/derive_bitfield_specifier/variant_out_of_range.rs:17:5
+   |
+17 |     External,
+   |     ^^^^^^^^ the trait `DiscriminantInRange` is not implemented for `False`
+   |
 help: the trait `DiscriminantInRange` is implemented for `True`
-   --> src/private/checks.rs
-    |
-    | impl DiscriminantInRange for True {}
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  --> src/private/checks.rs
+   |
+   | impl DiscriminantInRange for True {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckDiscriminantInRange::CheckType`
-   --> src/private/checks.rs
-    |
-    |     <Self::CheckType as DispatchTrueFalse>::Out: DiscriminantInRange,
-    |                                                  ^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckDiscriminantInRange::CheckType`
-    | {
-    |     type CheckType: DispatchTrueFalse;
-    |          --------- required by a bound in this associated type
+  --> src/private/checks.rs
+   |
+   |     <Self::CheckType as DispatchTrueFalse>::Out: DiscriminantInRange,
+   |                                                  ^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckDiscriminantInRange::CheckType`
+   | {
+   |     type CheckType: DispatchTrueFalse;
+   |          --------- required by a bound in this associated type
 
 error[E0277]: the trait bound `False: DiscriminantInRange` is not satisfied
- --> tests/ui/derive_bitfield_specifier/variant_out_of_range.rs:17:5
-  |
- 17 |     External,
-    |     ^^^^^^^^ the trait `DiscriminantInRange` is not implemented for `False`
-    |
+  --> tests/ui/derive_bitfield_specifier/variant_out_of_range.rs:17:5
+   |
+17 |     External,
+   |     ^^^^^^^^ the trait `DiscriminantInRange` is not implemented for `False`
+   |
 help: the trait `DiscriminantInRange` is implemented for `True`
-   --> src/private/checks.rs
-    |
-    | impl DiscriminantInRange for True {}
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  --> src/private/checks.rs
+   |
+   | impl DiscriminantInRange for True {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckDiscriminantInRange`
-   --> src/private/checks.rs
-    |
-    | pub trait CheckDiscriminantInRange<A>
-    |           ------------------------ required by a bound in this trait
-    | where
-    |     <Self::CheckType as DispatchTrueFalse>::Out: DiscriminantInRange,
-    |                                                  ^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckDiscriminantInRange`
-    = note: `CheckDiscriminantInRange` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::DiscriminantInRange`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-    = help: the following type implements the trait:
-              modular_bitfield::private::checks::True
+  --> src/private/checks.rs
+   |
+   | pub trait CheckDiscriminantInRange<A>
+   |           ------------------------ required by a bound in this trait
+   | where
+   |     <Self::CheckType as DispatchTrueFalse>::Out: DiscriminantInRange,
+   |                                                  ^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckDiscriminantInRange`
+   = note: `CheckDiscriminantInRange` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::DiscriminantInRange`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+   = help: the following type implements the trait:
+             modular_bitfield::private::checks::True

--- a/tests/ui/derive_default/duplicate_derive_default.rs
+++ b/tests/ui/derive_default/duplicate_derive_default.rs
@@ -1,0 +1,11 @@
+use modular_bitfield::prelude::*;
+
+#[bitfield]
+#[derive(Default)]
+#[derive(Default)]
+pub struct DuplicateDefault {
+    flag: bool,
+    value: B7,
+}
+
+fn main() {}

--- a/tests/ui/derive_default/duplicate_derive_default.stderr
+++ b/tests/ui/derive_default/duplicate_derive_default.stderr
@@ -1,0 +1,11 @@
+error: encountered duplicate `#[derive(Default)]` parameter
+ --> tests/ui/derive_default/duplicate_derive_default.rs:5:10
+  |
+5 | #[derive(Default)]
+  |          ^^^^^^^
+
+error: previous `#[derive(Default)]` parameter here
+ --> tests/ui/derive_default/duplicate_derive_default.rs:4:10
+  |
+4 | #[derive(Default)]
+  |          ^^^^^^^

--- a/tests/ui/derive_default/multiple_default_in_single_derive.rs
+++ b/tests/ui/derive_default/multiple_default_in_single_derive.rs
@@ -1,0 +1,10 @@
+use modular_bitfield::prelude::*;
+
+#[bitfield]
+#[derive(Default, Default)]
+pub struct MultipleDefaultInDerive {
+    flag: bool,
+    value: B7,
+}
+
+fn main() {}

--- a/tests/ui/derive_default/multiple_default_in_single_derive.stderr
+++ b/tests/ui/derive_default/multiple_default_in_single_derive.stderr
@@ -1,0 +1,11 @@
+error: encountered duplicate `#[derive(Default)]` parameter
+ --> tests/ui/derive_default/multiple_default_in_single_derive.rs:4:19
+  |
+4 | #[derive(Default, Default)]
+  |                   ^^^^^^^
+
+error: previous `#[derive(Default)]` parameter here
+ --> tests/ui/derive_default/multiple_default_in_single_derive.rs:4:10
+  |
+4 | #[derive(Default, Default)]
+  |          ^^^^^^^

--- a/tests/ui/derive_specifier/out_of_bounds.stderr
+++ b/tests/ui/derive_specifier/out_of_bounds.stderr
@@ -1,45 +1,45 @@
 error[E0277]: the trait bound `False: SpecifierHasAtMost128Bits` is not satisfied
  --> tests/ui/derive_specifier/out_of_bounds.rs:4:1
   |
-  4 | #[derive(Specifier, Debug)]
-    | ^ the trait `SpecifierHasAtMost128Bits` is not implemented for `False`
-    |
+4 | #[derive(Specifier, Debug)]
+  | ^ the trait `SpecifierHasAtMost128Bits` is not implemented for `False`
+  |
 help: the trait `SpecifierHasAtMost128Bits` is implemented for `True`
-   --> src/private/checks.rs
-    |
-    | impl SpecifierHasAtMost128Bits for True {}
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> src/private/checks.rs
+  |
+  | impl SpecifierHasAtMost128Bits for True {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckSpecifierHasAtMost128Bits::CheckType`
-   --> src/private/checks.rs
-    |
-    |     <Self::CheckType as DispatchTrueFalse>::Out: SpecifierHasAtMost128Bits,
-    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckSpecifierHasAtMost128Bits::CheckType`
-    | {
-    |     type CheckType: DispatchTrueFalse;
-    |          --------- required by a bound in this associated type
+ --> src/private/checks.rs
+  |
+  |     <Self::CheckType as DispatchTrueFalse>::Out: SpecifierHasAtMost128Bits,
+  |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckSpecifierHasAtMost128Bits::CheckType`
+  | {
+  |     type CheckType: DispatchTrueFalse;
+  |          --------- required by a bound in this associated type
 
 error[E0277]: the trait bound `False: SpecifierHasAtMost128Bits` is not satisfied
  --> tests/ui/derive_specifier/out_of_bounds.rs:4:1
   |
-  4 | #[derive(Specifier, Debug)]
-    | ^ the trait `SpecifierHasAtMost128Bits` is not implemented for `False`
-    |
+4 | #[derive(Specifier, Debug)]
+  | ^ the trait `SpecifierHasAtMost128Bits` is not implemented for `False`
+  |
 help: the trait `SpecifierHasAtMost128Bits` is implemented for `True`
-   --> src/private/checks.rs
-    |
-    | impl SpecifierHasAtMost128Bits for True {}
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> src/private/checks.rs
+  |
+  | impl SpecifierHasAtMost128Bits for True {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckSpecifierHasAtMost128Bits`
-   --> src/private/checks.rs
-    |
-    | pub trait CheckSpecifierHasAtMost128Bits
-    |           ------------------------------ required by a bound in this trait
-    | where
-    |     <Self::CheckType as DispatchTrueFalse>::Out: SpecifierHasAtMost128Bits,
-    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckSpecifierHasAtMost128Bits`
-    = note: `CheckSpecifierHasAtMost128Bits` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::SpecifierHasAtMost128Bits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-    = help: the following type implements the trait:
-              modular_bitfield::private::checks::True
+ --> src/private/checks.rs
+  |
+  | pub trait CheckSpecifierHasAtMost128Bits
+  |           ------------------------------ required by a bound in this trait
+  | where
+  |     <Self::CheckType as DispatchTrueFalse>::Out: SpecifierHasAtMost128Bits,
+  |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckSpecifierHasAtMost128Bits`
+  = note: `CheckSpecifierHasAtMost128Bits` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::SpecifierHasAtMost128Bits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+  = help: the following type implements the trait:
+            modular_bitfield::private::checks::True
 
 error[E0277]: the trait bound `BitCount<136>: ArrayBytesConversion` is not satisfied
  --> tests/ui/derive_specifier/out_of_bounds.rs:4:1

--- a/tests/ui/derive_specifier/out_of_bounds.stderr
+++ b/tests/ui/derive_specifier/out_of_bounds.stderr
@@ -1,37 +1,45 @@
 error[E0277]: the trait bound `False: SpecifierHasAtMost128Bits` is not satisfied
  --> tests/ui/derive_specifier/out_of_bounds.rs:4:1
   |
-4 | #[derive(Specifier, Debug)]
-  | ^ the trait `SpecifierHasAtMost128Bits` is not implemented for `False`
-  |
-  = help: the trait `SpecifierHasAtMost128Bits` is implemented for `True`
+  4 | #[derive(Specifier, Debug)]
+    | ^ the trait `SpecifierHasAtMost128Bits` is not implemented for `False`
+    |
+help: the trait `SpecifierHasAtMost128Bits` is implemented for `True`
+   --> src/private/checks.rs
+    |
+    | impl SpecifierHasAtMost128Bits for True {}
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckSpecifierHasAtMost128Bits::CheckType`
- --> src/private/checks.rs
-  |
-  |     <Self::CheckType as DispatchTrueFalse>::Out: SpecifierHasAtMost128Bits,
-  |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckSpecifierHasAtMost128Bits::CheckType`
-  | {
-  |     type CheckType: DispatchTrueFalse;
-  |          --------- required by a bound in this associated type
+   --> src/private/checks.rs
+    |
+    |     <Self::CheckType as DispatchTrueFalse>::Out: SpecifierHasAtMost128Bits,
+    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckSpecifierHasAtMost128Bits::CheckType`
+    | {
+    |     type CheckType: DispatchTrueFalse;
+    |          --------- required by a bound in this associated type
 
 error[E0277]: the trait bound `False: SpecifierHasAtMost128Bits` is not satisfied
  --> tests/ui/derive_specifier/out_of_bounds.rs:4:1
   |
-4 | #[derive(Specifier, Debug)]
-  | ^ the trait `SpecifierHasAtMost128Bits` is not implemented for `False`
-  |
-  = help: the trait `SpecifierHasAtMost128Bits` is implemented for `True`
+  4 | #[derive(Specifier, Debug)]
+    | ^ the trait `SpecifierHasAtMost128Bits` is not implemented for `False`
+    |
+help: the trait `SpecifierHasAtMost128Bits` is implemented for `True`
+   --> src/private/checks.rs
+    |
+    | impl SpecifierHasAtMost128Bits for True {}
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckSpecifierHasAtMost128Bits`
- --> src/private/checks.rs
-  |
-  | pub trait CheckSpecifierHasAtMost128Bits
-  |           ------------------------------ required by a bound in this trait
-  | where
-  |     <Self::CheckType as DispatchTrueFalse>::Out: SpecifierHasAtMost128Bits,
-  |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckSpecifierHasAtMost128Bits`
-  = note: `CheckSpecifierHasAtMost128Bits` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::SpecifierHasAtMost128Bits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-  = help: the following type implements the trait:
-            modular_bitfield::private::checks::True
+   --> src/private/checks.rs
+    |
+    | pub trait CheckSpecifierHasAtMost128Bits
+    |           ------------------------------ required by a bound in this trait
+    | where
+    |     <Self::CheckType as DispatchTrueFalse>::Out: SpecifierHasAtMost128Bits,
+    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckSpecifierHasAtMost128Bits`
+    = note: `CheckSpecifierHasAtMost128Bits` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::SpecifierHasAtMost128Bits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+    = help: the following type implements the trait:
+              modular_bitfield::private::checks::True
 
 error[E0277]: the trait bound `BitCount<136>: ArrayBytesConversion` is not satisfied
  --> tests/ui/derive_specifier/out_of_bounds.rs:4:1

--- a/tests/ui/filled_param/invalid_specified_as_filled.stderr
+++ b/tests/ui/filled_param/invalid_specified_as_filled.stderr
@@ -1,42 +1,42 @@
 error[E0277]: the trait bound `SevenMod8: TotalSizeIsMultipleOfEightBits` is not satisfied
  --> tests/ui/filled_param/invalid_specified_as_filled.rs:5:1
   |
- 5 | pub struct UnfilledBitfield {
-   | ^^^ the trait `TotalSizeIsMultipleOfEightBits` is not implemented for `SevenMod8`
-   |
+5 | pub struct UnfilledBitfield {
+  | ^^^ the trait `TotalSizeIsMultipleOfEightBits` is not implemented for `SevenMod8`
+  |
 help: the trait `TotalSizeIsMultipleOfEightBits` is implemented for `ZeroMod8`
-  --> src/private/checks.rs
-   |
-   | impl TotalSizeIsMultipleOfEightBits for ZeroMod8 {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> src/private/checks.rs
+  |
+  | impl TotalSizeIsMultipleOfEightBits for ZeroMod8 {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckTotalSizeMultipleOf8::Size`
-  --> src/private/checks.rs
-   |
-   |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsMultipleOfEightBits,
-   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeMultipleOf8::Size`
-   | {
-   |     type Size: RenameSizeType;
-   |          ---- required by a bound in this associated type
+ --> src/private/checks.rs
+  |
+  |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsMultipleOfEightBits,
+  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeMultipleOf8::Size`
+  | {
+  |     type Size: RenameSizeType;
+  |          ---- required by a bound in this associated type
 
 error[E0277]: the trait bound `SevenMod8: TotalSizeIsMultipleOfEightBits` is not satisfied
  --> tests/ui/filled_param/invalid_specified_as_filled.rs:5:1
   |
- 5 | pub struct UnfilledBitfield {
-   | ^^^ the trait `TotalSizeIsMultipleOfEightBits` is not implemented for `SevenMod8`
-   |
+5 | pub struct UnfilledBitfield {
+  | ^^^ the trait `TotalSizeIsMultipleOfEightBits` is not implemented for `SevenMod8`
+  |
 help: the trait `TotalSizeIsMultipleOfEightBits` is implemented for `ZeroMod8`
-  --> src/private/checks.rs
-   |
-   | impl TotalSizeIsMultipleOfEightBits for ZeroMod8 {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> src/private/checks.rs
+  |
+  | impl TotalSizeIsMultipleOfEightBits for ZeroMod8 {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckTotalSizeMultipleOf8`
-  --> src/private/checks.rs
-   |
-   | pub trait CheckTotalSizeMultipleOf8
-   |           ------------------------- required by a bound in this trait
-   | where
-   |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsMultipleOfEightBits,
-   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeMultipleOf8`
-   = note: `CheckTotalSizeMultipleOf8` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::TotalSizeIsMultipleOfEightBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-   = help: the following type implements the trait:
-             modular_bitfield::private::checks::ZeroMod8
+ --> src/private/checks.rs
+  |
+  | pub trait CheckTotalSizeMultipleOf8
+  |           ------------------------- required by a bound in this trait
+  | where
+  |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsMultipleOfEightBits,
+  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeMultipleOf8`
+  = note: `CheckTotalSizeMultipleOf8` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::TotalSizeIsMultipleOfEightBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+  = help: the following type implements the trait:
+            modular_bitfield::private::checks::ZeroMod8

--- a/tests/ui/filled_param/invalid_specified_as_filled.stderr
+++ b/tests/ui/filled_param/invalid_specified_as_filled.stderr
@@ -1,34 +1,42 @@
 error[E0277]: the trait bound `SevenMod8: TotalSizeIsMultipleOfEightBits` is not satisfied
  --> tests/ui/filled_param/invalid_specified_as_filled.rs:5:1
   |
-5 | pub struct UnfilledBitfield {
-  | ^^^ the trait `TotalSizeIsMultipleOfEightBits` is not implemented for `SevenMod8`
-  |
-  = help: the trait `TotalSizeIsMultipleOfEightBits` is implemented for `ZeroMod8`
+ 5 | pub struct UnfilledBitfield {
+   | ^^^ the trait `TotalSizeIsMultipleOfEightBits` is not implemented for `SevenMod8`
+   |
+help: the trait `TotalSizeIsMultipleOfEightBits` is implemented for `ZeroMod8`
+  --> src/private/checks.rs
+   |
+   | impl TotalSizeIsMultipleOfEightBits for ZeroMod8 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckTotalSizeMultipleOf8::Size`
- --> src/private/checks.rs
-  |
-  |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsMultipleOfEightBits,
-  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeMultipleOf8::Size`
-  | {
-  |     type Size: RenameSizeType;
-  |          ---- required by a bound in this associated type
+  --> src/private/checks.rs
+   |
+   |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsMultipleOfEightBits,
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeMultipleOf8::Size`
+   | {
+   |     type Size: RenameSizeType;
+   |          ---- required by a bound in this associated type
 
 error[E0277]: the trait bound `SevenMod8: TotalSizeIsMultipleOfEightBits` is not satisfied
  --> tests/ui/filled_param/invalid_specified_as_filled.rs:5:1
   |
-5 | pub struct UnfilledBitfield {
-  | ^^^ the trait `TotalSizeIsMultipleOfEightBits` is not implemented for `SevenMod8`
-  |
-  = help: the trait `TotalSizeIsMultipleOfEightBits` is implemented for `ZeroMod8`
+ 5 | pub struct UnfilledBitfield {
+   | ^^^ the trait `TotalSizeIsMultipleOfEightBits` is not implemented for `SevenMod8`
+   |
+help: the trait `TotalSizeIsMultipleOfEightBits` is implemented for `ZeroMod8`
+  --> src/private/checks.rs
+   |
+   | impl TotalSizeIsMultipleOfEightBits for ZeroMod8 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckTotalSizeMultipleOf8`
- --> src/private/checks.rs
-  |
-  | pub trait CheckTotalSizeMultipleOf8
-  |           ------------------------- required by a bound in this trait
-  | where
-  |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsMultipleOfEightBits,
-  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeMultipleOf8`
-  = note: `CheckTotalSizeMultipleOf8` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::TotalSizeIsMultipleOfEightBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-  = help: the following type implements the trait:
-            modular_bitfield::private::checks::ZeroMod8
+  --> src/private/checks.rs
+   |
+   | pub trait CheckTotalSizeMultipleOf8
+   |           ------------------------- required by a bound in this trait
+   | where
+   |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsMultipleOfEightBits,
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeMultipleOf8`
+   = note: `CheckTotalSizeMultipleOf8` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::TotalSizeIsMultipleOfEightBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+   = help: the following type implements the trait:
+             modular_bitfield::private::checks::ZeroMod8

--- a/tests/ui/filled_param/invalid_specified_as_unfilled.stderr
+++ b/tests/ui/filled_param/invalid_specified_as_unfilled.stderr
@@ -1,54 +1,54 @@
 error[E0277]: the trait bound `ZeroMod8: TotalSizeIsNotMultipleOfEightBits` is not satisfied
  --> tests/ui/filled_param/invalid_specified_as_unfilled.rs:5:1
   |
- 5 | pub struct UnfilledBitfield {
-   | ^^^ the trait `TotalSizeIsNotMultipleOfEightBits` is not implemented for `ZeroMod8`
-   |
-   = help: the following other types implement trait `TotalSizeIsNotMultipleOfEightBits`:
-             FiveMod8
-             FourMod8
-             OneMod8
-             SevenMod8
-             SixMod8
-             ThreeMod8
-             TwoMod8
+5 | pub struct UnfilledBitfield {
+  | ^^^ the trait `TotalSizeIsNotMultipleOfEightBits` is not implemented for `ZeroMod8`
+  |
+  = help: the following other types implement trait `TotalSizeIsNotMultipleOfEightBits`:
+            FiveMod8
+            FourMod8
+            OneMod8
+            SevenMod8
+            SixMod8
+            ThreeMod8
+            TwoMod8
 note: required by a bound in `CheckTotalSizeIsNotMultipleOf8::Size`
-  --> src/private/checks.rs
-   |
-   |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsNotMultipleOfEightBits,
-   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeIsNotMultipleOf8::Size`
-   | {
-   |     type Size: RenameSizeType;
-   |          ---- required by a bound in this associated type
+ --> src/private/checks.rs
+  |
+  |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsNotMultipleOfEightBits,
+  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeIsNotMultipleOf8::Size`
+  | {
+  |     type Size: RenameSizeType;
+  |          ---- required by a bound in this associated type
 
 error[E0277]: the trait bound `ZeroMod8: TotalSizeIsNotMultipleOfEightBits` is not satisfied
  --> tests/ui/filled_param/invalid_specified_as_unfilled.rs:5:1
   |
- 5 | pub struct UnfilledBitfield {
-   | ^^^ the trait `TotalSizeIsNotMultipleOfEightBits` is not implemented for `ZeroMod8`
-   |
-   = help: the following other types implement trait `TotalSizeIsNotMultipleOfEightBits`:
-             FiveMod8
-             FourMod8
-             OneMod8
-             SevenMod8
-             SixMod8
-             ThreeMod8
-             TwoMod8
+5 | pub struct UnfilledBitfield {
+  | ^^^ the trait `TotalSizeIsNotMultipleOfEightBits` is not implemented for `ZeroMod8`
+  |
+  = help: the following other types implement trait `TotalSizeIsNotMultipleOfEightBits`:
+            FiveMod8
+            FourMod8
+            OneMod8
+            SevenMod8
+            SixMod8
+            ThreeMod8
+            TwoMod8
 note: required by a bound in `CheckTotalSizeIsNotMultipleOf8`
-  --> src/private/checks.rs
-   |
-   | pub trait CheckTotalSizeIsNotMultipleOf8
-   |           ------------------------------ required by a bound in this trait
-   | where
-   |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsNotMultipleOfEightBits,
-   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeIsNotMultipleOf8`
-   = note: `CheckTotalSizeIsNotMultipleOf8` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::TotalSizeIsNotMultipleOfEightBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-   = help: the following types implement the trait:
-             modular_bitfield::private::checks::OneMod8
-             modular_bitfield::private::checks::TwoMod8
-             modular_bitfield::private::checks::ThreeMod8
-             modular_bitfield::private::checks::FourMod8
-             modular_bitfield::private::checks::FiveMod8
-             modular_bitfield::private::checks::SixMod8
-             modular_bitfield::private::checks::SevenMod8
+ --> src/private/checks.rs
+  |
+  | pub trait CheckTotalSizeIsNotMultipleOf8
+  |           ------------------------------ required by a bound in this trait
+  | where
+  |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsNotMultipleOfEightBits,
+  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeIsNotMultipleOf8`
+  = note: `CheckTotalSizeIsNotMultipleOf8` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::TotalSizeIsNotMultipleOfEightBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+  = help: the following types implement the trait:
+            modular_bitfield::private::checks::OneMod8
+            modular_bitfield::private::checks::TwoMod8
+            modular_bitfield::private::checks::ThreeMod8
+            modular_bitfield::private::checks::FourMod8
+            modular_bitfield::private::checks::FiveMod8
+            modular_bitfield::private::checks::SixMod8
+            modular_bitfield::private::checks::SevenMod8

--- a/tests/ui/filled_param/invalid_specified_as_unfilled.stderr
+++ b/tests/ui/filled_param/invalid_specified_as_unfilled.stderr
@@ -1,54 +1,54 @@
 error[E0277]: the trait bound `ZeroMod8: TotalSizeIsNotMultipleOfEightBits` is not satisfied
  --> tests/ui/filled_param/invalid_specified_as_unfilled.rs:5:1
   |
-5 | pub struct UnfilledBitfield {
-  | ^^^ the trait `TotalSizeIsNotMultipleOfEightBits` is not implemented for `ZeroMod8`
-  |
-  = help: the following other types implement trait `TotalSizeIsNotMultipleOfEightBits`:
-            FiveMod8
-            FourMod8
-            OneMod8
-            SevenMod8
-            SixMod8
-            ThreeMod8
-            TwoMod8
+ 5 | pub struct UnfilledBitfield {
+   | ^^^ the trait `TotalSizeIsNotMultipleOfEightBits` is not implemented for `ZeroMod8`
+   |
+   = help: the following other types implement trait `TotalSizeIsNotMultipleOfEightBits`:
+             FiveMod8
+             FourMod8
+             OneMod8
+             SevenMod8
+             SixMod8
+             ThreeMod8
+             TwoMod8
 note: required by a bound in `CheckTotalSizeIsNotMultipleOf8::Size`
- --> src/private/checks.rs
-  |
-  |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsNotMultipleOfEightBits,
-  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeIsNotMultipleOf8::Size`
-  | {
-  |     type Size: RenameSizeType;
-  |          ---- required by a bound in this associated type
+  --> src/private/checks.rs
+   |
+   |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsNotMultipleOfEightBits,
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeIsNotMultipleOf8::Size`
+   | {
+   |     type Size: RenameSizeType;
+   |          ---- required by a bound in this associated type
 
 error[E0277]: the trait bound `ZeroMod8: TotalSizeIsNotMultipleOfEightBits` is not satisfied
  --> tests/ui/filled_param/invalid_specified_as_unfilled.rs:5:1
   |
-5 | pub struct UnfilledBitfield {
-  | ^^^ the trait `TotalSizeIsNotMultipleOfEightBits` is not implemented for `ZeroMod8`
-  |
-  = help: the following other types implement trait `TotalSizeIsNotMultipleOfEightBits`:
-            FiveMod8
-            FourMod8
-            OneMod8
-            SevenMod8
-            SixMod8
-            ThreeMod8
-            TwoMod8
+ 5 | pub struct UnfilledBitfield {
+   | ^^^ the trait `TotalSizeIsNotMultipleOfEightBits` is not implemented for `ZeroMod8`
+   |
+   = help: the following other types implement trait `TotalSizeIsNotMultipleOfEightBits`:
+             FiveMod8
+             FourMod8
+             OneMod8
+             SevenMod8
+             SixMod8
+             ThreeMod8
+             TwoMod8
 note: required by a bound in `CheckTotalSizeIsNotMultipleOf8`
- --> src/private/checks.rs
-  |
-  | pub trait CheckTotalSizeIsNotMultipleOf8
-  |           ------------------------------ required by a bound in this trait
-  | where
-  |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsNotMultipleOfEightBits,
-  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeIsNotMultipleOf8`
-  = note: `CheckTotalSizeIsNotMultipleOf8` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::TotalSizeIsNotMultipleOfEightBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-  = help: the following types implement the trait:
-            modular_bitfield::private::checks::OneMod8
-            modular_bitfield::private::checks::TwoMod8
-            modular_bitfield::private::checks::ThreeMod8
-            modular_bitfield::private::checks::FourMod8
-            modular_bitfield::private::checks::FiveMod8
-            modular_bitfield::private::checks::SixMod8
-            modular_bitfield::private::checks::SevenMod8
+  --> src/private/checks.rs
+   |
+   | pub trait CheckTotalSizeIsNotMultipleOf8
+   |           ------------------------------ required by a bound in this trait
+   | where
+   |     <Self::Size as RenameSizeType>::CheckType: TotalSizeIsNotMultipleOfEightBits,
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckTotalSizeIsNotMultipleOf8`
+   = note: `CheckTotalSizeIsNotMultipleOf8` is a "sealed trait", because to implement it you also need to implement `modular_bitfield::private::checks::TotalSizeIsNotMultipleOfEightBits`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+   = help: the following types implement the trait:
+             modular_bitfield::private::checks::OneMod8
+             modular_bitfield::private::checks::TwoMod8
+             modular_bitfield::private::checks::ThreeMod8
+             modular_bitfield::private::checks::FourMod8
+             modular_bitfield::private::checks::FiveMod8
+             modular_bitfield::private::checks::SixMod8
+             modular_bitfield::private::checks::SevenMod8

--- a/tests/ui/multiple_of_8bits.stderr
+++ b/tests/ui/multiple_of_8bits.stderr
@@ -4,7 +4,11 @@ error[E0277]: the trait bound `SevenMod8: TotalSizeIsMultipleOfEightBits` is not
 54 | pub struct NotQuiteFourBytes {
    | ^^^ the trait `TotalSizeIsMultipleOfEightBits` is not implemented for `SevenMod8`
    |
-   = help: the trait `TotalSizeIsMultipleOfEightBits` is implemented for `ZeroMod8`
+help: the trait `TotalSizeIsMultipleOfEightBits` is implemented for `ZeroMod8`
+  --> src/private/checks.rs
+   |
+   | impl TotalSizeIsMultipleOfEightBits for ZeroMod8 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckTotalSizeMultipleOf8::Size`
   --> src/private/checks.rs
    |
@@ -20,7 +24,11 @@ error[E0277]: the trait bound `SevenMod8: TotalSizeIsMultipleOfEightBits` is not
 54 | pub struct NotQuiteFourBytes {
    | ^^^ the trait `TotalSizeIsMultipleOfEightBits` is not implemented for `SevenMod8`
    |
-   = help: the trait `TotalSizeIsMultipleOfEightBits` is implemented for `ZeroMod8`
+help: the trait `TotalSizeIsMultipleOfEightBits` is implemented for `ZeroMod8`
+  --> src/private/checks.rs
+   |
+   | impl TotalSizeIsMultipleOfEightBits for ZeroMod8 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `CheckTotalSizeMultipleOf8`
   --> src/private/checks.rs
    |

--- a/tests/ui/repr/invalid_repr_width_1.stderr
+++ b/tests/ui/repr/invalid_repr_width_1.stderr
@@ -1,11 +1,15 @@
 error[E0277]: the trait bound `BitCount<32>: IsU16Compatible` is not satisfied
  --> tests/ui/repr/invalid_repr_width_1.rs:4:8
   |
-4 | #[repr(u16)] // Too few bits!
-  |        ^^^ the trait `IsU16Compatible` is not implemented for `BitCount<32>`
-  |
-  = help: the trait `IsU16Compatible` is implemented for `BitCount<16>`
-  = help: see issue #48214
+ 4 | #[repr(u16)] // Too few bits!
+   |        ^^^ the trait `IsU16Compatible` is not implemented for `BitCount<32>`
+   |
+help: the trait `IsU16Compatible` is implemented for `BitCount<16>`
+  --> src/private/traits.rs
+   |
+   | impl IsU16Compatible for checks::BitCount<16> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: see issue #48214
 
 error[E0308]: mismatched types
  --> tests/ui/repr/invalid_repr_width_1.rs:4:8

--- a/tests/ui/repr/invalid_repr_width_1.stderr
+++ b/tests/ui/repr/invalid_repr_width_1.stderr
@@ -1,15 +1,15 @@
 error[E0277]: the trait bound `BitCount<32>: IsU16Compatible` is not satisfied
  --> tests/ui/repr/invalid_repr_width_1.rs:4:8
   |
- 4 | #[repr(u16)] // Too few bits!
-   |        ^^^ the trait `IsU16Compatible` is not implemented for `BitCount<32>`
-   |
+4 | #[repr(u16)] // Too few bits!
+  |        ^^^ the trait `IsU16Compatible` is not implemented for `BitCount<32>`
+  |
 help: the trait `IsU16Compatible` is implemented for `BitCount<16>`
-  --> src/private/traits.rs
-   |
-   | impl IsU16Compatible for checks::BitCount<16> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: see issue #48214
+ --> src/private/traits.rs
+  |
+  | impl IsU16Compatible for checks::BitCount<16> {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = help: see issue #48214
 
 error[E0308]: mismatched types
  --> tests/ui/repr/invalid_repr_width_1.rs:4:8

--- a/tests/ui/repr/invalid_repr_width_2.stderr
+++ b/tests/ui/repr/invalid_repr_width_2.stderr
@@ -1,11 +1,15 @@
 error[E0277]: the trait bound `BitCount<32>: IsU64Compatible` is not satisfied
  --> tests/ui/repr/invalid_repr_width_2.rs:4:8
   |
-4 | #[repr(u64)] // Too many bits!
-  |        ^^^ the trait `IsU64Compatible` is not implemented for `BitCount<32>`
-  |
-  = help: the trait `IsU64Compatible` is implemented for `BitCount<64>`
-  = help: see issue #48214
+ 4 | #[repr(u64)] // Too many bits!
+   |        ^^^ the trait `IsU64Compatible` is not implemented for `BitCount<32>`
+   |
+help: the trait `IsU64Compatible` is implemented for `BitCount<64>`
+  --> src/private/traits.rs
+   |
+   | impl IsU64Compatible for checks::BitCount<64> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: see issue #48214
 
 error[E0308]: mismatched types
  --> tests/ui/repr/invalid_repr_width_2.rs:4:8

--- a/tests/ui/repr/invalid_repr_width_2.stderr
+++ b/tests/ui/repr/invalid_repr_width_2.stderr
@@ -1,15 +1,15 @@
 error[E0277]: the trait bound `BitCount<32>: IsU64Compatible` is not satisfied
  --> tests/ui/repr/invalid_repr_width_2.rs:4:8
   |
- 4 | #[repr(u64)] // Too many bits!
-   |        ^^^ the trait `IsU64Compatible` is not implemented for `BitCount<32>`
-   |
+4 | #[repr(u64)] // Too many bits!
+  |        ^^^ the trait `IsU64Compatible` is not implemented for `BitCount<32>`
+  |
 help: the trait `IsU64Compatible` is implemented for `BitCount<64>`
-  --> src/private/traits.rs
-   |
-   | impl IsU64Compatible for checks::BitCount<64> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: see issue #48214
+ --> src/private/traits.rs
+  |
+  | impl IsU64Compatible for checks::BitCount<64> {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = help: see issue #48214
 
 error[E0308]: mismatched types
  --> tests/ui/repr/invalid_repr_width_2.rs:4:8


### PR DESCRIPTION
  Summary

  This PR implements default value support for bitfield structs, adding two major features:

  • #[default = ...] field attribute - Allows specifying default values for individual bitfield fields
  • #[derive(Default)] support - Automatically generates Default trait implementation that respects field defaults

  Features Added

  Field-Level Defaults with #[default(...)]

```rust
  #[bitfield]
  pub struct Config {
      enabled: bool,           // defaults to false (zero-initialized)
      #[default = true]
      auto_restart: bool,      // defaults to true
      #[default = 5]
      retry_count: B6,         // defaults to 5
      #[default =Mode::Auto]
      mode: Mode,             // defaults to Mode::Auto enum variant
  }
```

 Smart Constructor Behavior

  - new() - Applies field defaults while remaining const fn
  - new_zeroed() - Explicit zero-initialization (generated when defaults are used)
  - Both constructors work in const contexts

 Automatic Default Trait Implementation
```rust
  #[bitfield]
  #[derive(Default)]
  pub struct MyBitfield {
      #[default = 42]
      value: B8,
  }

  let bf = MyBitfield::default(); // Same as MyBitfield::new()
  assert_eq!(bf.value(), 42);
```
  Technical Implementation

 Const-Compatible Design

  - All default expressions must be const-evaluable (literals, const variables, enum variants)
  - Compile-time bit manipulation ensures zero runtime overhead
  - Both new() and new_zeroed() are const fn

  Example Usage
```rust
  use modular_bitfield::prelude::*;

  #[bitfield]
  #[derive(Default, Debug)]
  pub struct NetworkPacket {
      #[default = true ]
      enabled: bool,
      #[default = PacketType::Data]
      packet_type: PacketType,
      #[default = 1500]
      mtu: B12,
      payload_size: B20,  // defaults to 0
  }

  // Create with defaults applied
  let packet = NetworkPacket::default();
  assert!(packet.enabled());
  assert_eq!(packet.packet_type(), PacketType::Data);
  assert_eq!(packet.mtu(), 1500);
  assert_eq!(packet.payload_size(), 0);

  // Or explicitly zero-initialized
  let empty = NetworkPacket::new_zeroed();
```

this pull request closes #105 