### PR TITLE
Fix "unnecessary parentheses around type" warning

### DIFF
--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -144,8 +144,8 @@ impl BitfieldStruct {
                     self.#field_getter()
                         .as_ref()
                         .map_or_else(
-                            |__bf_err| __bf_err as &dyn (::core::fmt::Debug),
-                            |__bf_field| __bf_field as &dyn (::core::fmt::Debug)
+                            |__bf_err| __bf_err as &dyn ::core::fmt::Debug,
+                            |__bf_field| __bf_field as &dyn ::core::fmt::Debug
                         )
                 )
             ))


### PR DESCRIPTION
After updating to the latest nightly, my code spamming producing the warnings along the lines of:

```
warning: unnecessary parentheses around type
   --> n64/src/vi/control.rs:254:5
    |
254 |     pub v_burst_start: B10,
    |     ^                    ^
    |
help: remove these parentheses
    |
254 -     pub v_burst_start: B10,
254 +     ub v_burst_start: B1,
    |
```

Removing these parentheses appears to have fixed the warning. 