### PR TITLE
Properly retain repr arguments with parenthesis

### DIFF
--- a/impl/src/bitfield/analyse.rs
+++ b/impl/src/bitfield/analyse.rs
@@ -58,26 +58,26 @@ impl BitfieldStruct {
         for meta in repr_arguments {
             match meta {
                 syn::Meta::Path(path) => {
-            let repr_kind = if path.is_ident("u8") {
-                Some(ReprKind::U8)
-            } else if path.is_ident("u16") {
-                Some(ReprKind::U16)
-            } else if path.is_ident("u32") {
-                Some(ReprKind::U32)
-            } else if path.is_ident("u64") {
-                Some(ReprKind::U64)
-            } else if path.is_ident("u128") {
-                Some(ReprKind::U128)
-            } else {
-                // If other repr such as `transparent` or `C` have been found we
-                // are going to re-expand them into a new `#[repr(..)]` that is
-                // ignored by the rest of this macro.
+                    let repr_kind = if path.is_ident("u8") {
+                        Some(ReprKind::U8)
+                    } else if path.is_ident("u16") {
+                        Some(ReprKind::U16)
+                    } else if path.is_ident("u32") {
+                        Some(ReprKind::U32)
+                    } else if path.is_ident("u64") {
+                        Some(ReprKind::U64)
+                    } else if path.is_ident("u128") {
+                        Some(ReprKind::U128)
+                    } else {
+                        // If other repr such as `transparent` or `C` have been found we
+                        // are going to re-expand them into a new `#[repr(..)]` that is
+                        // ignored by the rest of this macro.
                         retained_reprs.push(path.clone().into());
-                None
-            };
-            if let Some(repr_kind) = repr_kind {
-                config.repr(repr_kind, path.span())?;
-            }
+                        None
+                    };
+                    if let Some(repr_kind) = repr_kind {
+                        config.repr(repr_kind, path.span())?;
+                    }
                 }
                 other => retained_reprs.push(other),
             }
@@ -231,5 +231,27 @@ impl BitfieldStruct {
             }
         }
         Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::ToTokens as _;
+
+    #[test]
+    fn retain_repr_arguments() {
+        let attr: syn::Attribute = syn::parse_quote!(#[repr(C, align(8))]);
+        let mut config = Config::default();
+
+        BitfieldStruct::extract_repr_attribute(&attr, &mut config).unwrap();
+
+        assert_eq!(config.retained_attributes.len(), 1);
+        let retained = &config.retained_attributes[0];
+        assert_eq!(
+            retained.to_token_stream().to_string(),
+            attr.to_token_stream().to_string(),
+            "repr arguments should be preserved when re-emitting retained repr attributes"
+        );
     }
 }

--- a/impl/src/bitfield/analyse.rs
+++ b/impl/src/bitfield/analyse.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use core::convert::TryFrom;
 use quote::quote;
-use syn::{self, parse::Result, spanned::Spanned as _};
+use syn::{self, parse::Result, punctuated::Punctuated, spanned::Spanned as _};
 
 impl TryFrom<(&mut Config, syn::ItemStruct)> for BitfieldStruct {
     type Error = syn::Error;
@@ -52,9 +52,12 @@ impl BitfieldStruct {
     /// Extracts the `#[repr(uN)]` annotations from the given `#[bitfield]` struct.
     fn extract_repr_attribute(attr: &syn::Attribute, config: &mut Config) -> Result<()> {
         let list = attr.meta.require_list()?;
-        let mut retained_reprs = vec![];
-        attr.parse_nested_meta(|meta| {
-            let path = &meta.path;
+        let repr_arguments: Punctuated<syn::Meta, syn::Token![,]> =
+            attr.parse_args_with(Punctuated::parse_terminated)?;
+        let mut retained_reprs = Vec::new();
+        for meta in repr_arguments {
+            match meta {
+                syn::Meta::Path(path) => {
             let repr_kind = if path.is_ident("u8") {
                 Some(ReprKind::U8)
             } else if path.is_ident("u16") {
@@ -69,14 +72,16 @@ impl BitfieldStruct {
                 // If other repr such as `transparent` or `C` have been found we
                 // are going to re-expand them into a new `#[repr(..)]` that is
                 // ignored by the rest of this macro.
-                retained_reprs.push(path.clone());
+                        retained_reprs.push(path.clone().into());
                 None
             };
             if let Some(repr_kind) = repr_kind {
                 config.repr(repr_kind, path.span())?;
             }
-            Ok(())
-        })?;
+                }
+                other => retained_reprs.push(other),
+            }
+        }
         if !retained_reprs.is_empty() {
             // We only push back another re-generated `#[repr(..)]` if its contents
             // contained some non-bitfield representations and thus is not empty.

--- a/tests/bitfield/regressions.rs
+++ b/tests/bitfield/regressions.rs
@@ -85,3 +85,18 @@ fn regression_v0_11() {
     assert!(flags.b());
     assert_eq!(flags.into_bytes(), [0b0000_0101]);
 }
+
+#[test]
+fn regression_issue_132() {
+    #[repr(C, align(1024))]
+    #[bitfield]
+    pub struct PackedData {
+        header: B4,
+        body: B9,
+        is_alive: B1,
+        status: B2,
+    }
+
+    // check alignment of PackedData
+    assert_eq!(core::mem::align_of::<PackedData>(), 1024);
+}


### PR DESCRIPTION
This fixes #132.

I added a unit test and a regression test, but I’m not fully sure if this matches the usual practice in this repo. Please take a look.

P.S. I really appreciate this crate and use it at work, but this issue is blocking our Rust toolchain upgrade. If this fix looks good to you, a quick release would be very helpful.